### PR TITLE
fixes references

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -30,8 +30,8 @@
         <div class="panel panel-default footer-links">
           <ul class="list-group">
             <li class="list-group-item"><a href="/contact-us">Contact Us</a></li>
-            <li class="list-group-item"><a href="/help/on-location">On Location</a></li>
-            <li class="list-group-item"><a href="/help/search">Search Help</a></li>
+            <li class="list-group-item"><a href="/on-location">On Location</a></li>
+            <li class="list-group-item"><a href="/search">Search Help</a></li>
             <li class="list-group-item"><a href="/resources">Resources</a></li>
             <li class="list-group-item"><a href="/social-media">Social Media</a></li>
           </ul>


### PR DESCRIPTION
I had forgotten to update the relative urls for "search" and "resources" when we moved them out of the help directory.