### PR TITLE
Link validation

### DIFF
--- a/app/views/override/help/using-the-ams.md
+++ b/app/views/override/help/using-the-ams.md
@@ -1,8 +1,8 @@
 # Accessing the AMS
-Staff at organizations that have contributed to the American Archive of Public Broadcasting may continue to access and manage records and digitized media through the [AMS](ams.americanarchive.org). 
+Staff at organizations that have contributed to the American Archive of Public Broadcasting may continue to access and manage records and digitized media through the [AMS](http://ams.americanarchive.org). 
 
 ## Logging into the AMS
-Open a browser window and navigate to [ams.americanarchive.org](ams.americanarchive.org). Enter your credentials and click the Sign In button. If you do not know your login credentials, email Casey Davis, Project Manager, at casey_davis@wgbh.org.
+Open a browser window and navigate to [ams.americanarchive.org](http://ams.americanarchive.org). Enter your credentials and click the Sign In button. If you do not know your login credentials, email Casey Davis, Project Manager, at casey_davis@wgbh.org.
 
 ## The Records Page
 Once logged in, click on the Record button at the top right of the screen. This page will display all of your organization’s records. When you first load the records page, notice that the default view is the Assets screen, highlighted in blue on the top left. You also can search instantiation records by clicking on the Instantiation tab, next to the highlighted Asset tab. Instantiation records provide you with detailed information about each copy of assets.

--- a/spec/support/.gitignore
+++ b/spec/support/.gitignore
@@ -1,0 +1,1 @@
+.link-check.txt

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -1,12 +1,15 @@
 require 'set'
+require 'curb'
 
 module LinkChecker
   @@checked = Set[]
   FILENAME = File.join(File.dirname(__FILE__),'.link-check.txt')
   RE_IGNORES = [
-    /^\/catalog\?/, # to many combos
+    /^\/catalog\?/, # too many combos
+    /^\/catalog\//, # redundant
     /^https?:/, # TODO: remote sites
-    /#/ # TODO: anchors
+    /#/, # TODO: anchors
+    /^mailto:/
   ]
   def self.needs_recheck?()
     return true if !File.exists?(FILENAME)
@@ -21,10 +24,17 @@ module LinkChecker
     return unless @@needs_recheck
     return if @@checked.include?(url)
     return if RE_IGNORES.map{|ignore| ignore.match(url)}.any?
-
-    fail("relative links are trouble: #{url}") if /^[^\/]/.match(url)
-    # TODO: try fetching with capybara
     @@checked << url
+    
+     # TODO: remote URLs
+    
+    fail("relative links are trouble: #{url}") if /^[^\/]/.match(url)
+
+    full_url = 'http://localhost:3000'+url
+    curl = Curl::Easy.http_get(full_url)
+    code = curl.response_code
+    fail("Got #{code} from #{full_url}") unless code == 200
+
     File.open(FILENAME, 'a') { |f| f.write(url) }
   end
 end

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -14,13 +14,14 @@ module LinkChecker
   def self.needs_recheck?()
     return true if !File.exists?(FILENAME)
     if (Time.now - File.mtime(FILENAME))/(60*60*24*7) > 1
-      File.unlink(FILE)
+      File.unlink(FILENAME)
       return true
     end
     return false
   end
   @@needs_recheck = self.needs_recheck?()
   def self.check(url)
+    return if ENV['CI'] # don't run on Travis
     return unless @@needs_recheck
     return if @@checked.include?(url)
     return if RE_IGNORES.map{|ignore| ignore.match(url)}.any?

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -3,16 +3,28 @@ require 'set'
 module LinkChecker
   @@checked = Set[]
   FILENAME = File.join(File.dirname(__FILE__),'.link-check.txt')
+  RE_IGNORES = [
+    /^\/catalog\?/, # to many combos
+    /^https?:/, # TODO: remote sites
+    /#/ # TODO: anchors
+  ]
   def self.needs_recheck?()
-    !File.exists?(FILENAME) ||
-      (Time.now - File.mtime(FILENAME))/(60*60*24*7) > 1
+    return true if !File.exists?(FILENAME)
+    if (Time.now - File.mtime(FILENAME))/(60*60*24*7) > 1
+      File.unlink(FILE)
+      return true
+    end
+    return false
   end
   @@needs_recheck = self.needs_recheck?()
   def self.check(url)
-    if @@needs_recheck && !@@checked.include?(url)
-      puts "TODO: check #{url}"
-      @@checked << url
-      File.open(FILENAME, 'a') { |f| f.write(url) }
-    end
+    return unless @@needs_recheck
+    return if @@checked.include?(url)
+    return if RE_IGNORES.map{|ignore| ignore.match(url)}.any?
+
+    fail("relative links are trouble: #{url}") if /^[^\/]/.match(url)
+    # TODO: try fetching with capybara
+    @@checked << url
+    File.open(FILENAME, 'a') { |f| f.write(url) }
   end
 end

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -1,0 +1,18 @@
+require 'set'
+
+module LinkChecker
+  @@checked = Set[]
+  FILENAME = File.join(File.dirname(__FILE__),'.link-check.txt')
+  def self.needs_recheck?()
+    !File.exists?(FILENAME) ||
+      (Time.now - File.mtime(FILENAME))/(60*60*24*7) > 1
+  end
+  @@needs_recheck = self.needs_recheck?()
+  def self.check(url)
+    if @@needs_recheck && !@@checked.include?(url)
+      puts "TODO: check #{url}"
+      @@checked << url
+      File.open(FILENAME, 'a') { |f| f.write(url) }
+    end
+  end
+end

--- a/spec/support/validation_helper.rb
+++ b/spec/support/validation_helper.rb
@@ -1,4 +1,5 @@
 require 'rexml/document'
+require_relative 'link_checker'
 
 module ValidationHelper
   def expect_fuzzy_xml
@@ -14,6 +15,8 @@ module ValidationHelper
 
     xhtml.gsub!(/<iframe[^>]+><\/iframe>/, '<!-- iframe was here -->')
     REXML::Document.new(xhtml)
+    
+    page.all('a').map{|element| element['href']}.each{|url| LinkChecker.check(url)}
   rescue => e
     numbered = xhtml.split(/\n/).each_with_index.map { |line, i| "#{i}:\t#{line}" }.join("\n")
     raise "XML validation failed: '#{e}'\n#{numbered}"

--- a/spec/support/validation_helper_spec.rb
+++ b/spec/support/validation_helper_spec.rb
@@ -2,24 +2,30 @@ require_relative 'validation_helper'
 require 'ostruct'
 
 describe ValidationHelper do
+  class Fake < OpenStruct
+    def all(_ignored)
+      []
+    end
+  end
+  
   describe 'obvious errors' do
     it 'catches mismatched tags' do
       def page
-        OpenStruct.new(body: '<html><a>TEXT</b></html>')
+        Fake.new(body: '<html><a>TEXT</b></html>')
       end
       expect { expect_fuzzy_xml }.to raise_error
     end
 
     it 'catches missing open brace' do
       def page
-        OpenStruct.new(body: '<html>a>TEXT</a></html>')
+        Fake.new(body: '<html>a>TEXT</a></html>')
       end
       expect { expect_fuzzy_xml }.to raise_error
     end
 
     it 'catches missing close brace' do
       def page
-        OpenStruct.new(body: '<html><aTEXT</a></html>')
+        Fake.new(body: '<html><aTEXT</a></html>')
       end
       expect { expect_fuzzy_xml }.to raise_error
     end
@@ -28,14 +34,14 @@ describe ValidationHelper do
   describe 'tag self closing' do
     it 'closes meta tags' do
       def page
-        OpenStruct.new(body: '<html><meta attribute="value"></html>')
+        Fake.new(body: '<html><meta attribute="value"></html>')
       end
       expect_fuzzy_xml
     end
 
     it 'does not close arbitrary tags' do
       def page
-        OpenStruct.new(body: '<html><arbitrary attribute="value"></html>')
+        Fake.new(body: '<html><arbitrary attribute="value"></html>')
       end
       expect { expect_fuzzy_xml }.to raise_error
     end
@@ -44,21 +50,21 @@ describe ValidationHelper do
   describe 'adding attribute values' do
     it 'adds values' do
       def page
-        OpenStruct.new(body: '<html><arbitrary attribute/></html>')
+        Fake.new(body: '<html><arbitrary attribute/></html>')
       end
       expect_fuzzy_xml
     end
 
     it 'keep previous / double quotes' do
       def page
-        OpenStruct.new(body: '<html><arbitrary prev ="foo" attribute/></html>')
+        Fake.new(body: '<html><arbitrary prev ="foo" attribute/></html>')
       end
       expect_fuzzy_xml
     end
 
     it 'keeps next / single quotes' do
       def page
-        OpenStruct.new(body: '<html><arbitrary attribute next= \'bar\'/></html>')
+        Fake.new(body: '<html><arbitrary attribute next= \'bar\'/></html>')
       end
       expect_fuzzy_xml
     end


### PR DESCRIPTION
I'd want to expand it, but even this found some dead links. The logic for when it's run is a little confusing:
- never on travis (environment variable)
- by default, once a week for developers. (But you can force more frequently by deleting the watch file.)

Particularly if we're hitting remote sites, it can slow down the test suite substantially... but if it's something you have to remember to turn on, then it's not going to happen. This seems like a good balance.

Just scanning for local links right now, and already found a couple bad ones, so I think it's worth it.