### PR TITLE
Link checker

### DIFF
--- a/scripts/lib/downloader.rb
+++ b/scripts/lib/downloader.rb
@@ -11,7 +11,8 @@ class Downloader
   KEY = 'b5f3288f3c6b6274c3455ec16a2bb67a'
   # From docs at https://github.com/avpreserve/AMS/blob/master/documentation/ams-web-services.md
   # ie, this not sensitive.
-
+  $LOG ||= NullLogger.new
+  
   def initialize(since) # rubocop:disable PerceivedComplexity, CyclomaticComplexity
     @since = since
     since.match(/(\d{4})(\d{2})(\d{2})/).tap do |match|
@@ -21,7 +22,6 @@ class Downloader
         match[2].to_i.instance_eval { |m| (1 <= m) && (m <= 12) } &&
         match[3].to_i.instance_eval { |d| (1 <= d) && (d <= 31) }
     end
-    $LOG ||= NullLogger.new
   end
 
   def self.download_to_directory_and_link(opts={})

--- a/spec/scripts/downloader_spec.rb
+++ b/spec/scripts/downloader_spec.rb
@@ -28,7 +28,7 @@ describe Downloader, not_on_travis: true do
 
   describe 'download by id' do
     it 'works' do
-      dir = Downloader.download_to_directory_and_link(ids: ['cpb-aacip/17-00000qrv'])
+      dir = Downloader.download_to_directory_and_link(ids: ['cpb-aacip/17-00000qrv'], is_same_mount: true)
       expect(dir).to match(/\d{4}-\d{2}-\d{2}.*_by_ids_1/)
       files = Dir["#{dir}/*.pbcore"]
       expect(files.map { |f| f.sub(/.*\//, '') }).to eq(['17-00000qrv.pbcore'])

--- a/spec/support/validation_helper.rb
+++ b/spec/support/validation_helper.rb
@@ -19,7 +19,7 @@ module ValidationHelper
     page.all('a').map { |element| element['href'] }.each { |url| LinkChecker.instance.check(url) }
   rescue => e
     numbered = xhtml.split(/\n/).each_with_index.map { |line, i| "#{i}:\t#{line}" }.join("\n")
-    raise "XML validation failed: #{e}\n#{e.backtrace}\n#{numbered}"
+    raise "XML validation failed: #{e}\n#{e.backtrace.join("\n")}\n#{numbered}"
   end
 end
 

--- a/spec/support/validation_helper.rb
+++ b/spec/support/validation_helper.rb
@@ -16,10 +16,10 @@ module ValidationHelper
     xhtml.gsub!(/<iframe[^>]+><\/iframe>/, '<!-- iframe was here -->')
     REXML::Document.new(xhtml)
 
-    page.all('a').map { |element| element['href'] }.each { |url| LinkChecker.check(url) }
+    page.all('a').map { |element| element['href'] }.each { |url| LinkChecker.instance.check(url) }
   rescue => e
     numbered = xhtml.split(/\n/).each_with_index.map { |line, i| "#{i}:\t#{line}" }.join("\n")
-    raise "XML validation failed: '#{e}'\n#{numbered}"
+    raise "XML validation failed: #{e}\n#{e.backtrace}\n#{numbered}"
   end
 end
 


### PR DESCRIPTION
This should be the end of the work for now. This would catch both 404s and too-many-redirects. The instances below are all examples of the latter.
```
$ rm ./spec/support/.link-check.txt
$ rspec --tag ~not_on_travis # Won't scan links if .link-check.txt is in place.
....
$ grep FAIL ./spec/support/.link-check.txt
FAIL: http://blog.americanarchive.org/2014/03/18/pbcore-is-back-in-action/
FAIL: http://www.current.org/wp-content/themes/current/archive-site/cpb/cpb1202archive.html
FAIL: http://ams.americanarchive.org
FAIL: http://www.archivematica.org
FAIL: http://blog.americanarchive.org
```