### PR TITLE
Remove "uncataloged" asset type. Fix #407.

### DIFF
--- a/config/vocab-maps/asset-type-map.yml
+++ b/config/vocab-maps/asset-type-map.yml
@@ -34,4 +34,4 @@
   Segrment: Segment
   Track: Track
   epi: Episode
-  '': Uncataloged
+  '': ''

--- a/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
@@ -1,5 +1,5 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
-  <pbcoreAssetType>Uncataloged</pbcoreAssetType>
+  <pbcoreAssetType></pbcoreAssetType>
   <pbcoreAssetDate dateType='created'>1990-07-27</pbcoreAssetDate>
   <pbcoreIdentifier source='MAVIS Title Number'>6875</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/151-2z12n4zx85</pbcoreIdentifier>


### PR DESCRIPTION
Requires reingest. Empty string in an element required by schema feels little weird, but is easier that customizing facet UI.