### PR TITLE
org config fixes

### DIFF
--- a/config/organizations.yml
+++ b/config/organizations.yml
@@ -3677,12 +3677,33 @@
   logo_filename: kcpt_logo.png
   url: http://www.kcpt.org/
   history_md: |
-   On March 29, 1961, Channel 19 signed on the air as KCSD, an instructional television station owned and operated by the Kansas City Missouri School District. Ten years later, when the district chose to relinquish its broadcast license, a group of civic leaders including Homer Wadsworth and Charles Curran used gifts from George Powell, Sr. and John Francis to provide for the establishment of a non-profit agency to create a public television station for Kansas City and the surrounding areas of Kansas and Missouri. Ownership of the broadcast license was granted in January 1972, creating a community-licensed public television station operating under the call letters KCPT. KCPT began transmitting national programs offered by the Public Broadcasting Service (PBS) in 1970.
-   Today KCPT is a telecommunications center serving over 2.2 million potential viewers with quality television programs available to anyone with a television set within a 34-county radius. Though now a community licensee, KCPT continues to provide education services to more than 120,000 students and 8,000+ teachers in K-12 schools with instructional television and online services within Missouri and Kansas. The station also provides educational programming and support services to early childhood students, parents and teachers and college distance learning efforts. 2013 brought two major changes to KCPT. The station purchased The Bridge, 90.9FM, a public radio all music format station, placing great emphasis on local musicians, and opened the Hale Center for Journalism focusing resources on regional stories.
+    On March 29, 1961, Channel 19 signed on the air as KCSD, an instructional 
+    television station owned and operated by the Kansas City Missouri School 
+    District. Ten years later, when the district chose to relinquish its broadcast 
+    license, a group of civic leaders including Homer Wadsworth and Charles Curran 
+    used gifts from George Powell, Sr. and John Francis to provide for the 
+    establishment of a non-profit agency to create a public television station 
+    for Kansas City and the surrounding areas of Kansas and Missouri. Ownership 
+    of the broadcast license was granted in January 1972, creating a 
+    community-licensed public television station operating under the call 
+    letters KCPT. KCPT began transmitting national programs offered by the 
+    Public Broadcasting Service (PBS) in 1970.
+    
+    Today KCPT is a telecommunications center serving over 2.2 million potential 
+    viewers with quality television programs available to anyone with a television 
+    set within a 34-county radius. Though now a community licensee, KCPT continues 
+    to provide education services to more than 120,000 students and 8,000+ 
+    teachers in K-12 schools with instructional television and online services 
+    within Missouri and Kansas. The station also provides educational programming 
+    and support services to early childhood students, parents and teachers and 
+    college distance learning efforts. 2013 brought two major changes to KCPT. 
+    The station purchased The Bridge, 90.9FM, a public radio all music format 
+    station, placing great emphasis on local musicians, and opened the Hale 
+    Center for Journalism focusing resources on regional stories.
   productions_md: |
-   - KC Illustrated
-   - Marquee
-   - State House Debates
+    - KC Illustrated
+    - Marquee
+    - State House Debates
 
 - pbcore_name: WHRO
   id: 1886


### PR DESCRIPTION
@sroosa: remember that you need a blank line in between to get paragraphs.

Also, line wrapping will make diffs easier to read.