### PR TITLE
Make titles 100x more important in text search.

### DIFF
--- a/jetty/solr/blacklight-core/conf/solrconfig.xml
+++ b/jetty/solr/blacklight-core/conf/solrconfig.xml
@@ -86,8 +86,8 @@
             http://wiki.apache.org/solr/LocalParams
        -->
 
-       <str name="qf">text</str>
-       <str name="pf">text</str>
+       <str name="qf">text titles^100</str>
+       <str name="pf">text titles^100</str>
        
        <str name="titles_qf">titles</str>
        <str name="titles_pf">titles</str>

--- a/jetty/solr/blacklight-core/conf/solrconfig.xml
+++ b/jetty/solr/blacklight-core/conf/solrconfig.xml
@@ -86,8 +86,8 @@
             http://wiki.apache.org/solr/LocalParams
        -->
 
-       <str name="qf">text titles^100</str>
-       <str name="pf">text titles^100</str>
+       <str name="qf">text titles^2</str>
+       <str name="pf">text titles^2</str>
        
        <str name="titles_qf">titles</str>
        <str name="titles_pf">titles</str>

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -140,7 +140,7 @@ describe 'Catalog' do
         describe 'relevance sorting' do
           assertions = [
             ['Iowa', ['Touchstone 108', 'Dr. Norman Borlaug', 'Musical Encounter']],
-            ['art', ['Unknown', 'Scheewe Art Workshop', 'A Sorting Test: 100']],
+            ['art', ['Scheewe Art Workshop', 'Unknown', 'A Sorting Test: 100']],
             ['John', ['Larry Kane On John Lennon 2005', 'Dr. Norman Borlaug']]
           ]
           assertions.each do |query, titles|


### PR DESCRIPTION
It does move the title which includes the search term up the list.
TODO: Is 100x right? Could it be over-weighted? Gather real examples.
Fixes #465.