### PR TITLE
Link to advanced search

### DIFF
--- a/app/views/catalog/_search_form_big.html.erb
+++ b/app/views/catalog/_search_form_big.html.erb
@@ -1,14 +1,7 @@
 <%= form_tag search_action_url, :method => :get, :class => 'search-query-form clearfix' do %>
 <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group input-group-lg search-group">
-    <% unless search_fields.empty? %>
-      <div class="input-group-addon">
-        <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
-        <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), :title => t('blacklight.search.form.search_field.title'), :class=>"search_field") %>
-        <span class="sr-only"><%= t('blacklight.search.form.search_field.post_label') %></span>
-      </div>
-    <% end %>
-
+    <!-- Selector removed: they can use advanced search. -->
     <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>
     <%= text_field_tag :q, params[:q], :placeholder => t('blacklight.search.form.q'), :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box? %>
     <span class="input-group-btn">
@@ -16,6 +9,10 @@
       <button type="submit" class="btn btn-primary search-btn" id="search">
         <span class="glyphicon glyphicon-search"></span>
         <!-- <span class="submit-search-text"><%=t('blacklight.search.form.submit')%></span> -->
+      </button>
+      
+      <button class="btn btn-primary search-btn" id="search" onclick="location='catalog';return false;" title="Advanced Search">
+        <span class="glyphicon glyphicon-menu-hamburger"></span>
       </button>
 
     </span>


### PR DESCRIPTION
- Making it an "a" would require more CSS tweaks, but maybe that would be better?
- Does not preserve entered search: if there are any search terms, then we don't get the advanced page. Is that ok? We could set up an actual, separate page at "/advanced", but I'm not sure that's warranted.
- Same thing for smaller search at top?

This PR can be handled independently of a PR for the search page itself.

For reference:
![screen shot 2015-06-30 at 1 23 13 pm](https://cloud.githubusercontent.com/assets/730388/8437306/34e879b4-1f2c-11e5-80f5-343df8be3d5a.png)
