### PR TITLE
Org in search results

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -41,6 +41,11 @@
                 <dd><%= date %></dd>
               </dl>
             <% end %>
+              
+            <dl class="clearfix">
+              <dt>Organization</dt>
+              <dd><%= pbcore.organization.short_name %></dd>
+            </dl>
 
           </div>
           <!-- END Column -->


### PR DESCRIPTION
Fix #510.

For example:
![screen shot 2015-07-08 at 1 44 19 pm](https://cloud.githubusercontent.com/assets/730388/8577606/cea9b3f0-2577-11e5-9aca-b4c82932605a.png)
