### PR TITLE
Remove duplicate values. Fix #482

### DIFF
--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -223,6 +223,20 @@ class Cleaner # rubocop:disable Metrics/ClassLength
       Cleaner.clean_language(node)
     }
 
+    # duplicate value removal
+    
+    seen_values = Set.new
+    ['/pbcoreTitle', '/pbcoreDescription', #
+        '/pbcoreInstantiation/instantiationIdentifier'].each { |name|
+      match(doc, name) { |node|
+        if seen_values.include?(node.text)
+          Cleaner.delete(node)
+        else
+          seen_values.add(node.text)
+        end
+      }
+    }
+    
     # formatting:
 
     formatter = REXML::Formatters::Pretty.new(2)

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -226,8 +226,10 @@ class Cleaner # rubocop:disable Metrics/ClassLength
     # duplicate value removal
     
     seen_values = Set.new
-    ['/pbcoreTitle', '/pbcoreDescription', #
+    ['/pbcoreTitle', '/pbcoreDescription', '/pbcoreRightsSummary/rightsSummary', #
         '/pbcoreInstantiation/instantiationIdentifier'].each { |name|
+        
+      
       match(doc, name) { |node|
         if seen_values.include?(node.text)
           Cleaner.delete(node)

--- a/spec/fixtures/pbcore/clean-basic.xml
+++ b/spec/fixtures/pbcore/clean-basic.xml
@@ -14,6 +14,10 @@
     <coverageType>Temporal</coverageType>
   </pbcoreCoverage>
   <pbcoreRightsSummary>
+    <rightsSummary>There should be only one.</rightsSummary>
+  </pbcoreRightsSummary>
+  <pbcoreRightsSummary>  </pbcoreRightsSummary>
+  <pbcoreRightsSummary>
     <rightsEmbedded>
       <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
     </rightsEmbedded>

--- a/spec/fixtures/pbcore/dirty-yes-fix-basic.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-basic.xml
@@ -12,6 +12,7 @@
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreDescription descriptionType="duplicate to be removed">No description available</pbcoreDescription>
   <pbcoreGenre source="WERU Genre Picklist">Readings</pbcoreGenre>
+  <pbcoreGenre source="duplicate to be removed">Readings</pbcoreGenre>
   <pbcoreCoverage>
     <coverage>mock value which should be preserved</coverage>
     <coverageType>Spatial</coverageType>
@@ -20,6 +21,12 @@
     <coverage>mock value which should be preserved</coverage>
     <coverageType>Temporal</coverageType>
   </pbcoreCoverage>
+  <pbcoreRightsSummary>
+     <rightsSummary>There should be only one.</rightsSummary>
+  </pbcoreRightsSummary>
+  <pbcoreRightsSummary>
+     <rightsSummary>There should be only one.</rightsSummary>
+  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source="WERU Prog List">WRF028</instantiationIdentifier>
     <instantiationIdentifier source="duplicate to be removed">Writers Forum</instantiationIdentifier>

--- a/spec/fixtures/pbcore/dirty-yes-fix-basic.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-basic.xml
@@ -7,8 +7,10 @@
   <pbcoreIdentifier source="WERU Prog List">WRF028</pbcoreIdentifier>
   <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/301-60cvdtx8</pbcoreIdentifier>
   <pbcoreTitle titleType="Series">Writers Forum</pbcoreTitle>
+  <pbcoreTitle titleType="duplicate to be removed">Writers Forum</pbcoreTitle>
   <pbcoreTitle titleType="Program">WRF-09/13/07</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
+  <pbcoreDescription descriptionType="duplicate to be removed">No description available</pbcoreDescription>
   <pbcoreGenre source="WERU Genre Picklist">Readings</pbcoreGenre>
   <pbcoreCoverage>
     <coverage>mock value which should be preserved</coverage>
@@ -20,6 +22,7 @@
   </pbcoreCoverage>
   <pbcoreInstantiation>
     <instantiationIdentifier source="WERU Prog List">WRF028</instantiationIdentifier>
+    <instantiationIdentifier source="duplicate to be removed">Writers Forum</instantiationIdentifier>
     <instantiationPhysical>CD</instantiationPhysical>
     <instantiationLocation>WERU Archives - CD Shelves</instantiationLocation>
     <instantiationMediaType>Sound</instantiationMediaType>


### PR DESCRIPTION
@caseyedavis12 / @sroosa : Have we seen this problem in any field beyond title, description, and instantiation identifier? Not a problem to make it broader... but it shouldn't be applied to every single element: ie, it's not a problem if multiple instantiationDurations have the same value.