### PR TITLE
Online-reading-room privs backend

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -123,8 +123,17 @@ class PBCore # rubocop:disable Metrics/ClassLength
   def organization_state_abbreviation
     @organization_state_abbreviation ||= organization.state_abbreviation
   end
-  def rights_code
-    @rights_code ||= 'PUBLIC' # TODO: replace with boolean getters
+  def access_level
+    @access_level ||= xpath('/*/pbcoreAnnotation[@annotationType="Level of User Access"]')
+  end
+  def public? # AKA online reading room
+    access_level == 'Online Reading Room'
+  end
+  def protected? # AKA on site
+    access_level == 'On Location'
+  end 
+  def private? # AKA not even on site
+    access_level == 'Private' # TODO: Confirm that this is the right string.
   end
   MOVING_IMAGE = 'Moving Image'
   SOUND = 'Sound'
@@ -332,7 +341,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
   # These methods are only used by to_solr.
 
   def text
-    ignores = [:text, :to_solr, :contribs, :img_src, :media_srcs, :rights_code, 
+    ignores = [:text, :to_solr, :contribs, :img_src, :media_srcs, :rights_code, :access_level,
                :access_types, :titles_sort, :ci_ids, :instantiations, :organization_state_abbreviation]
     @text ||= (PBCore.instance_methods(false) - ignores)
               .reject { |method| method =~ /\?$/ } # skip booleans

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -124,7 +124,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
     @organization_state_abbreviation ||= organization.state_abbreviation
   end
   def rights_code
-    @rights_code ||= xpath('/*/pbcoreRightsSummary/rightsEmbedded/AAPB_RIGHTS_CODE')
+    @rights_code ||= 'PUBLIC' # TODO: replace with boolean getters
   end
   MOVING_IMAGE = 'Moving Image'
   SOUND = 'Sound'

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -167,9 +167,12 @@ class PBCore # rubocop:disable Metrics/ClassLength
     # xpaths('/*/pbcoreInstantiation/instantiationGenerations').include?('Proxy')
   end
   def access_types
-    @access_types ||= ['All'].tap do|types|
-      types << 'Digitized' if digitized?
-      # TODO: distinguish if available off-site
+    @access_types ||= ['All'].tap do |types|
+      types << 'On site' if ( protected? || public? ) && digitized? 
+      types << 'Online reading room' if public? && digitized?
+      # "All" covers everything.
+      # "On site" covers everything which is digitized and not private.
+      # "ORR" covers everything which is digitized and public.
     end
   end
 

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -166,20 +166,6 @@ class Cleaner # rubocop:disable Metrics/ClassLength
       Cleaner.delete(node)
     }
 
-    # pbcoreRightsSummary:
-
-    match(doc, '[not(pbcoreRightsSummary/rightsEmbedded/AAPB_RIGHTS_CODE)]') { |node|
-      Cleaner.insert_after_match(
-        node,
-        Cleaner.any('pbcore',
-                    %w(Description Genre Relation Coverage AudienceLevel) +
-                    %w(AudienceRating Creator Contributor Publisher RightsSummary)),
-        REXML::Document.new('<pbcoreRightsSummary><rightsEmbedded><AAPB_RIGHTS_CODE>' \
-                          'ON_LOCATION_ONLY' \
-                          '</AAPB_RIGHTS_CODE></rightsEmbedded></pbcoreRightsSummary>')
-      )
-    }
-
     # pbcoreInstantiation:
 
     match(doc, '/pbcoreInstantiation[not(instantiationIdentifier)]') { |node|

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -93,7 +93,7 @@ describe 'Catalog' do
           ['asset_type', 1, 'Segment', 5],
           ['organization', 1, 'WGBH+(MA)', 2],
           ['year', 1, '2000', 1],
-          ['access_types', 2, 'All', 23]
+          ['access_types', 3, 'All', 23]
         ]
         assertions.each do |facet, facet_count, value, value_count|
           url = "/catalog?f[#{facet}][]=#{value}"

--- a/spec/fixtures/dci/pbcore-dir/pbcore.xml
+++ b/spec/fixtures/dci/pbcore-dir/pbcore.xml
@@ -29,11 +29,6 @@
   <pbcoreRightsSummary>
     <rightsSummary>Copy Left: All rights reversed.</rightsSummary>
   </pbcoreRightsSummary>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>PUBLIC</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='foo'>ABC</instantiationIdentifier>
     <instantiationDate dateType='encoded'>2001-02-03</instantiationDate>
@@ -43,4 +38,5 @@
     <instantiationDuration>0:12:34</instantiationDuration>
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='organization'>WGBH</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-MOCK.xml
+++ b/spec/fixtures/pbcore/clean-MOCK.xml
@@ -29,11 +29,6 @@
   <pbcoreRightsSummary>
     <rightsSummary>Copy Left: All rights reversed.</rightsSummary>
   </pbcoreRightsSummary>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>PUBLIC</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='foo'>ABC</instantiationIdentifier>
     <instantiationDate dateType='encoded'>2001-02-03</instantiationDate>

--- a/spec/fixtures/pbcore/clean-MOCK.xml
+++ b/spec/fixtures/pbcore/clean-MOCK.xml
@@ -46,4 +46,5 @@
     <instantiationDuration>1:23:45</instantiationDuration>
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='organization'>WGBH</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/clean-bad-essence-track.xml
@@ -69,4 +69,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-03 03:00:54</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WNYC-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/clean-bad-essence-track.xml
@@ -22,11 +22,6 @@
     <publisher>WQXR</publisher>
     <publisherRole>Publisher</publisherRole>
   </pbcorePublisher>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WNYC Media Archive Label'>72208.1</instantiationIdentifier>
     <instantiationIdentifier source='pbcore XML database UUID'>f60bd50b-1471-4afb-bbdb-700a3ef1e3ed</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-bad-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-language.xml
@@ -18,11 +18,6 @@
     <coverage>English</coverage>
     <coverageType>Spatial</coverageType>
   </pbcoreCoverage>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='Tape Number'/>
     <instantiationIdentifier source='Shelf Number'>Bin 48 - COL5- Shelf B- Box 1 or 2</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-bad-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-language.xml
@@ -30,4 +30,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:31:56</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Iowa Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-media-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-media-type.xml
@@ -21,4 +21,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-17 17:28:33</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>KXCI Community Radio</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-media-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-media-type.xml
@@ -5,11 +5,6 @@
     Podcast Release Form Bajo Turbato Performers/Instruments: Chris Black,
     Gabriel Sullivan Track Titles: 2010-02-01
   </pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='KXC'>KXCI03022</instantiationIdentifier>
     <instantiationDate dateType='created'>2010-02-01</instantiationDate>

--- a/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
@@ -13,11 +13,6 @@
     <contributor>Miles Educational Film Productions, Inc.</contributor>
     <contributorRole>Compiler</contributorRole>
   </pbcoreContributor>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='MAVIS Carrier Number'>6875-1-1</instantiationIdentifier>
     <instantiationIdentifier source='MAVIS Item ID'>33120</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
@@ -40,4 +40,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2014-08-22 23:26:39</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Film &amp; Media Archive, Washington University in St. Louis</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-title-type-substring.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type-substring.xml
@@ -33,4 +33,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-01 16:21:33</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WPBS</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-title-type-substring.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type-substring.xml
@@ -20,11 +20,6 @@
   <pbcoreRightsSummary>
     <rightsSummary>Copyright 2001, St Lawrence Valley ETV Council, INC.</rightsSummary>
   </pbcoreRightsSummary>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='unknown'>03213</instantiationIdentifier>
     <instantiationDate dateType='broadcast'>2013-06-01</instantiationDate>

--- a/spec/fixtures/pbcore/clean-bad-title-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type.xml
@@ -16,4 +16,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 17:41:26</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Detroit Public Television (aka DPTV and WTVS)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-bad-title-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type.xml
@@ -4,11 +4,6 @@
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/240-12893cp0</pbcoreIdentifier>
   <pbcoreTitle titleType='Uncataloged'>Scheewe Art Workshop</pbcoreTitle>
   <pbcoreDescription>TAPE 5</pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WTVS DATABASE ID'>WTVS000613</instantiationIdentifier>
     <instantiationDate dateType='created'>2007-07-10</instantiationDate>

--- a/spec/fixtures/pbcore/clean-basic.xml
+++ b/spec/fixtures/pbcore/clean-basic.xml
@@ -13,11 +13,6 @@
     <coverage>mock value which should be preserved</coverage>
     <coverageType>Temporal</coverageType>
   </pbcoreCoverage>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WERU Prog List'>WRF028</instantiationIdentifier>
     <instantiationPhysical>CD</instantiationPhysical>

--- a/spec/fixtures/pbcore/clean-basic.xml
+++ b/spec/fixtures/pbcore/clean-basic.xml
@@ -23,4 +23,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-03 01:50:55</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WERU-FM (WERU Community Radio)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-coverage-type-lc.xml
+++ b/spec/fixtures/pbcore/clean-coverage-type-lc.xml
@@ -33,4 +33,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-17 14:09:28</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Maryland Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-coverage-type-lc.xml
+++ b/spec/fixtures/pbcore/clean-coverage-type-lc.xml
@@ -21,11 +21,6 @@
     <publisher>Maryland Public Television</publisher>
     <publisherRole>Copyright Holder</publisherRole>
   </pbcorePublisher>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='Maryland Public Television'>18037</instantiationIdentifier>
     <instantiationPhysical>Betacam</instantiationPhysical>

--- a/spec/fixtures/pbcore/clean-empty-coverage-type.xml
+++ b/spec/fixtures/pbcore/clean-empty-coverage-type.xml
@@ -26,4 +26,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-18 00:28:53</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WXPN-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-empty-coverage-type.xml
+++ b/spec/fixtures/pbcore/clean-empty-coverage-type.xml
@@ -14,11 +14,6 @@
     <contributor>WXPN</contributor>
     <contributorRole>Producer</contributorRole>
   </pbcoreContributor>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WXPN Barcode'>7006</instantiationIdentifier>
     <instantiationDate dateType='created'>1997-01-20</instantiationDate>

--- a/spec/fixtures/pbcore/clean-empty-description.xml
+++ b/spec/fixtures/pbcore/clean-empty-description.xml
@@ -10,11 +10,6 @@
     <creator>Radio</creator>
     <creatorRole>Production Unit</creatorRole>
   </pbcoreCreator>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WGBH Item ID'>88-0009-00-03-008</instantiationIdentifier>
     <instantiationIdentifier source='WGBH Barcode'>0000221665</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-empty-description.xml
+++ b/spec/fixtures/pbcore/clean-empty-description.xml
@@ -25,4 +25,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-22 16:27:47</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WGBH</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-every-title-is-episode-number.xml
+++ b/spec/fixtures/pbcore/clean-every-title-is-episode-number.xml
@@ -10,11 +10,6 @@
   <pbcoreTitle titleType='Episode Number'>116</pbcoreTitle>
   <pbcoreTitle titleType='Episode Number'>Music for Fun</pbcoreTitle>
   <pbcoreDescription>Rec Eng MM/SK, 30 minutes, MBR-30</pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='Tape Number'>32H014</instantiationIdentifier>
     <instantiationIdentifier source='Shelf Number'>32E-COL4/1</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-every-title-is-episode-number.xml
+++ b/spec/fixtures/pbcore/clean-every-title-is-episode-number.xml
@@ -155,4 +155,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:33:17</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Iowa Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-has-rights-already.xml
+++ b/spec/fixtures/pbcore/clean-has-rights-already.xml
@@ -44,4 +44,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-17 17:41:40</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>KUOW Puget Sound Public Radio</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-has-rights-already.xml
+++ b/spec/fixtures/pbcore/clean-has-rights-already.xml
@@ -25,11 +25,6 @@
   <pbcoreRightsSummary>
     <rightsSummary> 2011 KUOW Puget Sound Public Radio</rightsSummary>
   </pbcoreRightsSummary>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='File name'>weekdayb20061120</instantiationIdentifier>
     <instantiationIdentifier source='KUOW Puget Sound Public Radio'>24748</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-no-contributor.xml
+++ b/spec/fixtures/pbcore/clean-no-contributor.xml
@@ -24,4 +24,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-07-11 14:42:15</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WIAA-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-contributor.xml
+++ b/spec/fixtures/pbcore/clean-no-contributor.xml
@@ -13,11 +13,6 @@
       Copyright is held by Interlochen Center for the Arts.
     </rightsSummary>
   </pbcoreRightsSummary>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='unknown'/>
     <instantiationPhysical>1/4 inch audio tape</instantiationPhysical>

--- a/spec/fixtures/pbcore/clean-no-creator.xml
+++ b/spec/fixtures/pbcore/clean-no-creator.xml
@@ -9,4 +9,5 @@
   </pbcorePublisher>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:19:31</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WGVU Public TV &amp; Radio</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-creator.xml
+++ b/spec/fixtures/pbcore/clean-no-creator.xml
@@ -7,11 +7,6 @@
     <publisher>WGVU</publisher>
     <publisherRole>Distributor</publisherRole>
   </pbcorePublisher>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:19:31</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WGVU Public TV &amp; Radio</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-identifier-source.xml
@@ -27,4 +27,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-18 00:33:34</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WXPN-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-identifier-source.xml
@@ -14,11 +14,6 @@
     <creator>WXPN</creator>
     <creatorRole>Producer</creatorRole>
   </pbcoreCreator>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WXPN Barcode'>015415</instantiationIdentifier>
     <instantiationIdentifier source='WXPN Label'>Copy 2</instantiationIdentifier>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
@@ -7,11 +7,6 @@
     <publisher>IND</publisher>
     <publisherRole>Source</publisherRole>
   </pbcorePublisher>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='unknown'/>
     <instantiationLocation/>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
@@ -15,4 +15,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 16:41:49</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WHUT-TV (Howard University Television)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
@@ -25,4 +25,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-18 00:41:06</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WXPN-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
@@ -13,11 +13,6 @@
     <creator>WXPN</creator>
     <creatorRole>Producer</creatorRole>
   </pbcoreCreator>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='unknown'>008147</instantiationIdentifier>
     <instantiationDate dateType='created'>2004-03-05</instantiationDate>

--- a/spec/fixtures/pbcore/clean-no-instantiation.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation.xml
@@ -3,11 +3,6 @@
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/304-579s52qf</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>The Sorting Test: 1</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:28:16</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WUSF</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-instantiation.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation.xml
@@ -5,4 +5,5 @@
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:28:16</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WUSF</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-publisher.xml
+++ b/spec/fixtures/pbcore/clean-no-publisher.xml
@@ -12,11 +12,6 @@
     complete.??Aired as part of Intensity TV 113 intense Drama: on Death and
     Dying"
   </pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='KQED AAP'>32-2271-H;43211</instantiationIdentifier>
     <instantiationDate dateType='created'>2000-10-02</instantiationDate>

--- a/spec/fixtures/pbcore/clean-no-publisher.xml
+++ b/spec/fixtures/pbcore/clean-no-publisher.xml
@@ -23,4 +23,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:39:31</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>KQED</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-relation-type.xml
+++ b/spec/fixtures/pbcore/clean-no-relation-type.xml
@@ -48,4 +48,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2014-07-31 19:53:13</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Iowa Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-no-relation-type.xml
+++ b/spec/fixtures/pbcore/clean-no-relation-type.xml
@@ -22,11 +22,6 @@
   <pbcoreRightsSummary>
     <rightsSummary>Undefined</rightsSummary>
   </pbcoreRightsSummary>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='Iowa Public Television'>iptvtst_19821225_108</instantiationIdentifier>
     <instantiationPhysical>3/4 inch videotape: U-matic</instantiationPhysical>

--- a/spec/fixtures/pbcore/clean-rename-attribute.xml
+++ b/spec/fixtures/pbcore/clean-rename-attribute.xml
@@ -30,4 +30,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-18 12:07:13</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WNYC-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-rename-attribute.xml
+++ b/spec/fixtures/pbcore/clean-rename-attribute.xml
@@ -19,11 +19,6 @@
     Aristocrats, the new film about one very dirty joke. Go to the films website
     Gilbert Gottfrieds website
   </pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='TAK'>test</instantiationIdentifier>
     <instantiationDate dateType='availableStart'>2013-06-12</instantiationDate>

--- a/spec/fixtures/pbcore/clean-sorting.xml
+++ b/spec/fixtures/pbcore/clean-sorting.xml
@@ -3,11 +3,6 @@
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/240-07tmpw1x</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>SORTING Test: 2</pbcoreTitle>
   <pbcoreDescription>#5+7</pbcoreDescription>
-  <pbcoreRightsSummary>
-    <rightsEmbedded>
-      <AAPB_RIGHTS_CODE>ON_LOCATION_ONLY</AAPB_RIGHTS_CODE>
-    </rightsEmbedded>
-  </pbcoreRightsSummary>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WTVS DATABASE ID'>WTVS009483</instantiationIdentifier>
     <instantiationPhysical>Film: 16mm print</instantiationPhysical>

--- a/spec/fixtures/pbcore/clean-sorting.xml
+++ b/spec/fixtures/pbcore/clean-sorting.xml
@@ -13,4 +13,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 17:41:21</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>Detroit Public Television (aka DPTV and WTVS)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-no-fix-multi-aai-id.xml
+++ b/spec/fixtures/pbcore/dirty-no-fix-multi-aai-id.xml
@@ -44,4 +44,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 05:39:11</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Louisiana Public Broadcasting</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-no-fix-skeleton.xml
+++ b/spec/fixtures/pbcore/dirty-no-fix-skeleton.xml
@@ -3,4 +3,5 @@
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreAnnotation annotationType="last_modified">2014-07-18 08:01:00</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Wisconsin Public Television (WHA-TV)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-essence-track.xml
@@ -66,4 +66,5 @@
     </pbcoreInstantiation>
     <pbcoreAnnotation annotationType="last_modified">2013-06-03 03:00:54</pbcoreAnnotation>
     <pbcoreAnnotation annotationType="organization">WNYC-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-language.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-language.xml
@@ -27,4 +27,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 06:31:56</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Iowa Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-media-type.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-media-type.xml
@@ -23,4 +23,5 @@ Track Titles:
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-17 17:28:33</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">KXCI Community Radio</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-relation-and-language.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-relation-and-language.xml
@@ -38,4 +38,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2014-08-22 23:26:39</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Film &amp; Media Archive, Washington University in St. Louis</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-title-type-substring.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-title-type-substring.xml
@@ -32,4 +32,5 @@ producer Natasha Neuroth</pbcoreDescription>
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-01 16:21:33</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WPBS</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-title-type.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-title-type.xml
@@ -16,4 +16,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 17:41:26</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Detroit Public Television (aka DPTV and WTVS)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-basic.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-basic.xml
@@ -28,4 +28,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-03 01:50:55</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WERU-FM (WERU Community Radio)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-coverage-type-lc.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-coverage-type-lc.xml
@@ -34,4 +34,5 @@ C. Miller part 2</pbcoreDescription>
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-17 14:09:28</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Maryland Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-empty-coverage-type.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-empty-coverage-type.xml
@@ -31,4 +31,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-18 00:28:53</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WXPN-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-empty-description.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-empty-description.xml
@@ -25,4 +25,5 @@
     </pbcoreInstantiation>
     <pbcoreAnnotation annotationType="last_modified">2013-06-22 16:27:47</pbcoreAnnotation>
     <pbcoreAnnotation annotationType="organization">WGBH</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-every-title-is-episode-number.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-every-title-is-episode-number.xml
@@ -155,4 +155,5 @@
     </pbcoreInstantiation>
     <pbcoreAnnotation annotationType="last_modified">2013-06-02 06:33:17</pbcoreAnnotation>
     <pbcoreAnnotation annotationType="organization">Iowa Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-has-rights-already.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-has-rights-already.xml
@@ -41,4 +41,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-17 17:41:40</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">KUOW Puget Sound Public Radio</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-contributor.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-contributor.xml
@@ -21,4 +21,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-07-11 14:42:15</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WIAA-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-creator.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-creator.xml
@@ -12,4 +12,5 @@
   </pbcorePublisher>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 06:19:31</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WGVU Public TV &amp; Radio</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-identifier-source.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-identifier-source.xml
@@ -27,4 +27,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-18 00:33:34</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WXPN-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-instantiation-identifier-location-mediaType.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-instantiation-identifier-location-mediaType.xml
@@ -12,4 +12,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 16:41:49</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WHUT-TV (Howard University Television)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-instantiation-identifier-source.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-instantiation-identifier-source.xml
@@ -26,4 +26,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-18 00:41:06</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WXPN-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-instantiation.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-instantiation.xml
@@ -5,4 +5,5 @@
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 06:28:16</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">WUSF</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-publisher.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-publisher.xml
@@ -18,4 +18,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 06:39:31</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">KQED</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-no-relation-type.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-no-relation-type.xml
@@ -52,4 +52,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2014-07-31 19:53:13</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Iowa Public Television</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-rename-attribute.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-rename-attribute.xml
@@ -14,4 +14,5 @@
     </pbcoreInstantiation>
     <pbcoreAnnotation annotationType="last_modified">2013-06-18 12:07:13</pbcoreAnnotation>
     <pbcoreAnnotation annotationType="organization">WNYC-FM</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-yes-fix-sorting.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-sorting.xml
@@ -13,4 +13,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType="last_modified">2013-06-02 17:41:21</pbcoreAnnotation>
   <pbcoreAnnotation annotationType="organization">Detroit Public Television (aka DPTV and WTVS)</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -89,6 +89,7 @@ describe 'Validated and plain PBCore' do
           'access_types' => ['All', 'Digitized']
         },
         access_types: ['All', 'Digitized'],
+        access_level: 'Online Reading Room',
         asset_type: 'Album',
         asset_date: '2000-01-01',
         asset_dates: [['uncataloged', '2000-01-01']],
@@ -111,7 +112,9 @@ describe 'Validated and plain PBCore' do
         organization_pbcore_name: 'WGBH',
         organization: Organization.find_by_pbcore_name('WGBH'),        
         organization_state_abbreviation: 'MA',
-        rights_code: 'PUBLIC',
+        private?: false,
+        protected?: false,
+        public?: true,
         media_type: 'Moving Image',
         video?: true,
         audio?: false,

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -86,9 +86,9 @@ describe 'Validated and plain PBCore' do
           'topics' => ['Music'],
           'asset_type' => 'Album',
           'organization' => 'WGBH (MA)',
-          'access_types' => ['All', 'Digitized']
+          'access_types' => ['All', 'On site', 'Online reading room']
         },
-        access_types: ['All', 'Digitized'],
+        access_types: ['All', 'On site', 'Online reading room'],
         access_level: 'Online Reading Room',
         asset_type: 'Album',
         asset_date: '2000-01-01',


### PR DESCRIPTION
@afred: If you haven't already done the reindex, it would be nice to get this in before you do. In any even, it requires the new form of pbcore core: *Don't* deploy it against an old index; Ok, but not ideal to deploy it against new index, but without a reindex just for the cleaning changes this introduces.

(Note that this doesn't actually use the new access information: control is still based solely on IP.)