### PR TITLE
Warnings raised by link checker

### DIFF
--- a/app/views/override/about-the-american-archive/history/page3.md
+++ b/app/views/override/about-the-american-archive/history/page3.md
@@ -26,7 +26,7 @@ Library of Congress, Television and Video Preservation 1997, 1:71.
 <a name="4"></a><sup>4</sup>Ibid.
 
 <a name="5"></a><sup>5</sup>American Television and Radio Archives Act, 2 U.S.C. § 170, 
-<https://www.law.cornell.edu/uscode/text/2/170.> The Library of Congress 
+<https://www.law.cornell.edu/uscode/text/2/170> The Library of Congress 
 already had acquired in 1965 16mm prints of 550 National Educational Television 
 (NET) programs from the Educational Television and Radio Center in Ann Arbor, 
 and in 1975, the Library received 96 additional 16mm NET films from WNET. 

--- a/spec/fixtures/pbcore/clean-MOCK.xml
+++ b/spec/fixtures/pbcore/clean-MOCK.xml
@@ -47,5 +47,5 @@
   </pbcoreInstantiation>
   <pbcoreAnnotation annotationType='organization'>WGBH</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
-  <pbcoreAnnotation annotationType='Outside URL'>http://example.org/outside-video-link</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='Outside URL'>http://www.wgbh.org/</pbcoreAnnotation>
 </pbcoreDescriptionDocument>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -114,7 +114,7 @@ describe 'Validated and plain PBCore' do
         captions_src: '/captions/1234.txt',
         organization_pbcore_name: 'WGBH',
         organization: Organization.find_by_pbcore_name('WGBH'),
-        outside_url: 'http://example.org/outside-video-link',
+        outside_url: 'http://www.wgbh.org/',
         private?: false,
         protected?: false,
         public?: true,


### PR DESCRIPTION
The page3 link is the only one that matters, and removing the dot fixes it.