### PR TITLE
Make the official title a semicolon delimited list.

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -71,7 +71,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
     @titles ||= pairs_by_type('/*/pbcoreTitle', '@titleType')
   end
   def title
-    @title ||= titles.reverse.map { |pair| pair.last }.join('; ')
+    @title ||= titles.map { |pair| pair.last }.join('; ')
   end
   def exhibits
     @exhibits ||= Exhibit.find_by_item_id(id).map { |exhibit| exhibit.path }

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -64,14 +64,14 @@ class PBCore # rubocop:disable Metrics/ClassLength
     nil
   end
   def titles_sort
-    @titles_sort ||= titles.reverse.map { |pair| pair.last }.join(' -- ')
+    # TODO: If title is stable, remove this. https://github.com/WGBH/AAPB2/issues/569
+    @titles_sort ||= title
   end
   def titles
     @titles ||= pairs_by_type('/*/pbcoreTitle', '@titleType')
   end
   def title
-    @title ||= xpaths('/*/pbcoreTitle[@titleType!="Episode Number"]').first ||
-               xpaths('/*/pbcoreTitle').first # There are records that only have "Episode Number"
+    @title ||= titles.reverse.map { |pair| pair.last }.join('; ')
   end
   def exhibits
     @exhibits ||= Exhibit.find_by_item_id(id).map { |exhibit| exhibit.path }

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -22,7 +22,7 @@
           <!-- START Column -->
           <div class="col-md-9">
 
-            <h2><%= link_to_document(document, pbcore.titles.map(&:second).join(', ')) %></h2>
+            <h2><%= link_to_document(document, pbcore.title) %></h2>
             
             <%= render partial: 'exhibit_item', 
                        locals: { document: document } %>

--- a/config/vocab-maps/title-type-map.yml
+++ b/config/vocab-maps/title-type-map.yml
@@ -6,22 +6,22 @@
 # Final line is a fall-through.
 
 !omap
-  album: Album
-  b roll: Raw Footage
-  b-roll: Raw Footage
-  element: Raw Footage
-  field tape: Raw Footage
-  raw: Raw Footage
-  promo: Promo
-  trailer: Promo
-  advertis: Promo
-  clip: Clip
-  number: Episode Number
-  episode: Episode
-  epospde: Episode
-  segment: Segment
-  program: Program
-  series: Series
-  collection: Collection
   label: Label
+  collection: Collection
+  series: Series
+  program: Program
+  segment: Segment
+  number: Episode Number
+  epospde: Episode
+  episode: Episode
+  clip: Clip
+  advertis: Promo
+  trailer: Promo
+  promo: Promo
+  raw: Raw Footage
+  field tape: Raw Footage
+  element: Raw Footage
+  b-roll: Raw Footage
+  b roll: Raw Footage
+  album: Album
   '': Uncataloged

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -178,9 +178,9 @@ describe 'Catalog' do
 
         describe 'relevance sorting' do
           assertions = [
-            ['Iowa', ['Touchstone 108', 'Dr. Norman Borlaug, B-Roll', 'Musical Encounter, 116, Music for Fun']],
+            ['Iowa', ['Touchstone 108', 'B-Roll; Dr. Norman Borlaug', 'Music for Fun; 116; Musical Encounter']],
             ['art', ['Scheewe Art Workshop', 'Unknown', 'A Sorting Test: 100']],
-            ['John', ['Larry Kane On John Lennon 2005, World Cafe', 'Dr. Norman Borlaug, B-Roll']]
+            ['John', ['World Cafe; Larry Kane On John Lennon 2005', 'B-Roll; Dr. Norman Borlaug']]
           ]
           assertions.each do |query, titles|
             url = "/catalog?q=#{query}"
@@ -195,8 +195,8 @@ describe 'Catalog' do
 
         describe 'field sorting' do
           assertions = [
-            ['year+desc', '3-2-1, Kaboom!, Gratuitous Explosions, Nova'],
-            ['year+asc', 'Musical Encounter, 116, Music for Fun'],
+            ['year+desc', 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1'],
+            ['year+asc', 'Music for Fun; 116; Musical Encounter'],
             ['title+asc', 'Ask Governor Chris Gregoire']
           ]
           assertions.each do |sort, title|

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -178,9 +178,9 @@ describe 'Catalog' do
 
         describe 'relevance sorting' do
           assertions = [
-            ['Iowa', ['Touchstone 108', 'B-Roll; Dr. Norman Borlaug', 'Music for Fun; 116; Musical Encounter']],
+            ['Iowa', ['Touchstone 108', 'Dr. Norman Borlaug; B-Roll', 'Musical Encounter; 116; Music for Fun']],
             ['art', ['Scheewe Art Workshop', 'Unknown', 'A Sorting Test: 100']],
-            ['John', ['World Cafe; Larry Kane On John Lennon 2005', 'B-Roll; Dr. Norman Borlaug']]
+            ['John', ['World Cafe; Larry Kane On John Lennon 2005', 'Dr. Norman Borlaug; B-Roll']]
           ]
           assertions.each do |query, titles|
             url = "/catalog?q=#{query}"
@@ -195,8 +195,8 @@ describe 'Catalog' do
 
         describe 'field sorting' do
           assertions = [
-            ['year+desc', 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1'],
-            ['year+asc', 'Music for Fun; 116; Musical Encounter'],
+            ['year+desc', 'Nova; Gratuitous Explosions; 3-2-1; Kaboom!'],
+            ['year+asc', 'Musical Encounter; 116; Music for Fun'],
             ['title+asc', 'Ask Governor Chris Gregoire']
           ]
           assertions.each do |sort, title|
@@ -226,32 +226,32 @@ describe 'Catalog' do
               page.all('#documents/div').map do |doc| 
                 doc.all('dl').map do |dl|
                   "#{dl.find('dt').text}: #{dl.find('dd').text[0..20]}"
-                end
-              end).to eq([
+                end.join('; ')
+              end.join("\n")).to eq([
                 ['Program: Ask Governor Chris Gr', 'Organization: KUOW Puget Sound Publ'],
-                ['Episode: #508', 'Series: Askc: Ask Congress', 'Organization: WHUT'],
+                ['Series: Askc: Ask Congress', 'Episode: #508', 'Organization: WHUT'],
                 ['Raw Footage: Dr. Norman Borlaug', 'Raw Footage: B-Roll', 'Organization: Iowa Public Televisio'],
                 ['Uncataloged: Dry Spell', 'Organization: KQED'],
+                ['Program: Four Decades of Dedic', 'Uncataloged: Handles missing title', 'Organization: WPBS'],
                 ['Uncataloged: From Bessie Smith to ', 'Created: 1990-07-27', 'Uncataloged: 1991-07-27', 'Organization: Film and Media Archiv'],
                 ['Series: Gvsports', 'Organization: WGVU Public TV and Ra'],
-                ['Program: Four Decades of Dedic', 'Uncataloged: Handles missing title', 'Organization: WPBS'],
                 ['Raw Footage: MSOM Field Tape - BUG', 'Organization: Maryland Public Telev'],
                 ['Episode Number: Musical Encounter', 'Episode Number: 116', 'Episode Number: Music for Fun', 'Created: 1988-05-12', 'Organization: Iowa Public Televisio'],
-                ['Episode Number: 3-2-1', 'Episode: Kaboom!', 'Program: Gratuitous Explosions', 'Series: Nova', 'Uncataloged: 2000-01-01', 'Organization: WGBH'],
+                ['Series: Nova', 'Program: Gratuitous Explosions', 'Episode Number: 3-2-1', 'Episode: Kaboom!', 'Uncataloged: 2000-01-01', 'Organization: WGBH'],
                 ['Uncataloged: Podcast Release Form', 'Organization: KXCI Community Radio'],
-                ['Program: MacLeod: The Palace G', 'Series: Reading Aloud', 'Organization: WGBH'],
+                ['Series: Reading Aloud', 'Program: MacLeod: The Palace G', 'Organization: WGBH'],
                 ['Uncataloged: Scheewe Art Workshop', 'Organization: Detroit Public Televi'],
                 ['Program: The Sorting Test: 1', 'Organization: WUSF'],
                 ['Program: SORTING Test: 2', 'Organization: Detroit Public Televi'],
                 ['Program: A Sorting Test: 100', 'Organization: WNYC'],
                 ['Episode: Touchstone 108', 'Organization: Iowa Public Televisio'],
                 ['Program: Unknown', 'Organization: WIAA'],
-                ['Segment: Howard Kramer 2004', 'Program: World Cafe', 'Organization: WXPN'],
-                ['Segment: Larry Kane On John Le', 'Program: World Cafe', 'Organization: WXPN'],
-                ['Segment: Martin Luther King, J', 'Segment: 1997-01-20 Sat/Mon', 'Program: World Cafe', 'Organization: WXPN'],
-                ['Episode: Judd Hirsch', 'Series: This is My Music', 'Collection: WQXR', 'Organization: WNYC'],
-                ['Program: WRF-09/13/07', 'Series: Writers Forum', 'Organization: WERU Community Radio']
-              ])
+                ['Program: World Cafe', 'Segment: Howard Kramer 2004', 'Organization: WXPN'],
+                ['Program: World Cafe', 'Segment: Larry Kane On John Le', 'Organization: WXPN'],
+                ['Program: World Cafe', 'Segment: 1997-01-20 Sat/Mon', 'Segment: Martin Luther King, J', 'Organization: WXPN'],
+                ['Collection: WQXR', 'Series: This is My Music', 'Episode: Judd Hirsch', 'Organization: WNYC'],
+                ['Series: Writers Forum', 'Program: WRF-09/13/07', 'Organization: WERU Community Radio']
+              ].map{|x| x.join('; ')}.join("\n"))
             expect_fuzzy_xml
           end
         end

--- a/spec/fixtures/pbcore/clean-MOCK.xml
+++ b/spec/fixtures/pbcore/clean-MOCK.xml
@@ -5,10 +5,10 @@
   <pbcoreIdentifier source='somewhere else'>5678</pbcoreIdentifier>
   <pbcoreIdentifier source='Sony Ci'>a-32-digit-hex</pbcoreIdentifier>
   <pbcoreIdentifier source='Sony Ci'>another-32-digit-hex</pbcoreIdentifier>
+  <pbcoreTitle titleType='Series'>Nova</pbcoreTitle>
+  <pbcoreTitle titleType='Program'>Gratuitous Explosions</pbcoreTitle>
   <pbcoreTitle titleType='Episode Number'>3-2-1</pbcoreTitle>
   <pbcoreTitle titleType='Episode'>Kaboom!</pbcoreTitle>
-  <pbcoreTitle titleType='Program'>Gratuitous Explosions</pbcoreTitle>
-  <pbcoreTitle titleType='Series'>Nova</pbcoreTitle>
   <pbcoreSubject>explosions -- gratuitious</pbcoreSubject>
   <pbcoreSubject>musicals -- horror</pbcoreSubject>
   <pbcoreDescription>&lt;removed by html scrubber&gt;Best episode ever!</pbcoreDescription>

--- a/spec/fixtures/pbcore/clean-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/clean-bad-essence-track.xml
@@ -2,9 +2,9 @@
   <pbcoreIdentifier source='WNYC Archive Catalog'>72208</pbcoreIdentifier>
   <pbcoreIdentifier source='pbcore XML database UUID'>986dd7a4-fd14-4e51-ab8b-3dbea66fd504</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/80-12893j6c</pbcoreIdentifier>
-  <pbcoreTitle titleType='Episode'>Judd Hirsch</pbcoreTitle>
-  <pbcoreTitle titleType='Series'>This is My Music</pbcoreTitle>
   <pbcoreTitle titleType='Collection'>WQXR</pbcoreTitle>
+  <pbcoreTitle titleType='Series'>This is My Music</pbcoreTitle>
+  <pbcoreTitle titleType='Episode'>Judd Hirsch</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreRelation>
     <pbcoreRelationType>Is Part Of</pbcoreRelationType>

--- a/spec/fixtures/pbcore/clean-basic.xml
+++ b/spec/fixtures/pbcore/clean-basic.xml
@@ -2,8 +2,8 @@
   <!-- Root attributes are screwy in AMS export. -->
   <pbcoreIdentifier source='WERU Prog List'>WRF028</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/301-60cvdtx8</pbcoreIdentifier>
-  <pbcoreTitle titleType='Program'>WRF-09/13/07</pbcoreTitle>
   <pbcoreTitle titleType='Series'>Writers Forum</pbcoreTitle>
+  <pbcoreTitle titleType='Program'>WRF-09/13/07</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreCoverage>
     <coverage>mock value which should be preserved</coverage>

--- a/spec/fixtures/pbcore/clean-empty-coverage-type.xml
+++ b/spec/fixtures/pbcore/clean-empty-coverage-type.xml
@@ -3,9 +3,9 @@
   <pbcoreIdentifier source='WXPN Barcode'>7006</pbcoreIdentifier>
   <pbcoreIdentifier source='WXPN'>Martin Luther King, Jr.</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/155-859cp21j</pbcoreIdentifier>
-  <pbcoreTitle titleType='Segment'>Martin Luther King, Jr. 1997</pbcoreTitle>
-  <pbcoreTitle titleType='Segment'>1997-01-20 Sat/Mon</pbcoreTitle>
   <pbcoreTitle titleType='Program'>World Cafe</pbcoreTitle>
+  <pbcoreTitle titleType='Segment'>1997-01-20 Sat/Mon</pbcoreTitle>
+  <pbcoreTitle titleType='Segment'>Martin Luther King, Jr. 1997</pbcoreTitle>
   <pbcoreSubject>Interview</pbcoreSubject>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreGenre annotation='genre'>Interview</pbcoreGenre>

--- a/spec/fixtures/pbcore/clean-empty-description.xml
+++ b/spec/fixtures/pbcore/clean-empty-description.xml
@@ -3,8 +3,8 @@
   <pbcoreIdentifier source='MARS Source Creation Order'>275829</pbcoreIdentifier>
   <pbcoreIdentifier source='WGBH Old File Number'>P03649,W01263</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/15-042rd7dg</pbcoreIdentifier>
-  <pbcoreTitle titleType='Program'>MacLeod: The Palace Guard</pbcoreTitle>
   <pbcoreTitle titleType='Series'>Reading Aloud</pbcoreTitle>
+  <pbcoreTitle titleType='Program'>MacLeod: The Palace Guard</pbcoreTitle>
   <pbcoreDescription/>
   <pbcoreCreator>
     <creator>Radio</creator>

--- a/spec/fixtures/pbcore/clean-no-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-identifier-source.xml
@@ -3,8 +3,8 @@
   <pbcoreIdentifier source='WXPN'>Larry Kane</pbcoreIdentifier>
   <pbcoreIdentifier source='unknown'>John Lennon</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/155-17crjgpf</pbcoreIdentifier>
-  <pbcoreTitle titleType='Segment'>Larry Kane On John Lennon 2005</pbcoreTitle>
   <pbcoreTitle titleType='Program'>World Cafe</pbcoreTitle>
+  <pbcoreTitle titleType='Segment'>Larry Kane On John Lennon 2005</pbcoreTitle>
   <pbcoreSubject source='PBS'>MUSIC</pbcoreSubject>
   <pbcoreSubject>Interview</pbcoreSubject>
   <pbcoreDescription>ACROSS THE UNIVERSE</pbcoreDescription>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/293-10wpzhr8</pbcoreIdentifier>
-  <pbcoreTitle titleType='Episode'>#508</pbcoreTitle>
   <pbcoreTitle titleType='Series'>Askc: Ask Congress</pbcoreTitle>
+  <pbcoreTitle titleType='Episode'>#508</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcorePublisher>
     <publisher>IND</publisher>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
@@ -2,8 +2,8 @@
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source='WXPN Barcode'>Howard Kramer</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/155-451g1rsx</pbcoreIdentifier>
-  <pbcoreTitle titleType='Segment'>Howard Kramer 2004</pbcoreTitle>
   <pbcoreTitle titleType='Program'>World Cafe</pbcoreTitle>
+  <pbcoreTitle titleType='Segment'>Howard Kramer 2004</pbcoreTitle>
   <pbcoreSubject>Interview</pbcoreSubject>
   <pbcoreSubject source='PBS'>MUSIC</pbcoreSubject>
   <pbcoreDescription>Rock and Roll Hall of Fame 2004</pbcoreDescription>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -73,12 +73,13 @@ describe 'Validated and plain PBCore' do
             'Copy Left: All rights reversed.', #
             'Album', 'Uncataloged', '2000-01-01', #
             'Episode Number', '3-2-1', 'Episode', 'Kaboom!', #
-            'Program', 'Gratuitous Explosions', 'Series', 'Nova', '1234', #
+            'Program', 'Gratuitous Explosions', 'Series', 'Nova', # 
+            'Nova; Gratuitous Explosions; Kaboom!; 3-2-1', '1234', #
             'AAPB ID', 'somewhere else', '5678', #
             'WGBH', 'Boston', 'Massachusetts', #
             'Moving Image', '1:23:45'],
           'titles' => ['3-2-1', 'Kaboom!', 'Gratuitous Explosions', 'Nova'],
-          'title' => 'Nova -- Gratuitous Explosions -- Kaboom! -- 3-2-1',
+          'title' => 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1',
           'contribs' => ['Larry', 'Stooges', 'Curly', 'Stooges', 'Moe', 'Stooges'],
           'year' => '2000',
           'exhibits' => [],
@@ -95,10 +96,10 @@ describe 'Validated and plain PBCore' do
         asset_type: 'Album',
         asset_date: '2000-01-01',
         asset_dates: [['Uncataloged', '2000-01-01']],
-        titles_sort: 'Nova -- Gratuitous Explosions -- Kaboom! -- 3-2-1',
+        titles_sort: 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1',
         titles: [['Episode Number', '3-2-1'], ['Episode', 'Kaboom!'], #
                  ['Program', 'Gratuitous Explosions'], ['Series', 'Nova']],
-        title: 'Kaboom!',
+        title: 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1',
         exhibits: [],
         descriptions: ['Best episode ever!'],
         instantiations: [PBCore::Instantiation.new('Moving Image', 'should be ignored!'),

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -72,14 +72,14 @@ describe 'Validated and plain PBCore' do
             'Curly', 'bald', 'Stooges', 'Larry', 'balding', 'Moe', 'hair', #
             'Copy Left: All rights reversed.', #
             'Album', 'Uncataloged', '2000-01-01', #
+            'Series', 'Nova', 'Program', 'Gratuitous Explosions', # 
             'Episode Number', '3-2-1', 'Episode', 'Kaboom!', #
-            'Program', 'Gratuitous Explosions', 'Series', 'Nova', # 
-            'Nova; Gratuitous Explosions; Kaboom!; 3-2-1', '1234', #
+            'Nova; Gratuitous Explosions; 3-2-1; Kaboom!', '1234', #
             'AAPB ID', 'somewhere else', '5678', #
             'WGBH', 'Boston', 'Massachusetts', #
             'Moving Image', '1:23:45'],
-          'titles' => ['3-2-1', 'Kaboom!', 'Gratuitous Explosions', 'Nova'],
-          'title' => 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1',
+          'titles' => ['Nova', 'Gratuitous Explosions', '3-2-1', 'Kaboom!'],
+          'title' => 'Nova; Gratuitous Explosions; 3-2-1; Kaboom!',
           'contribs' => ['Larry', 'Stooges', 'Curly', 'Stooges', 'Moe', 'Stooges'],
           'year' => '2000',
           'exhibits' => [],
@@ -96,10 +96,10 @@ describe 'Validated and plain PBCore' do
         asset_type: 'Album',
         asset_date: '2000-01-01',
         asset_dates: [['Uncataloged', '2000-01-01']],
-        titles_sort: 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1',
-        titles: [['Episode Number', '3-2-1'], ['Episode', 'Kaboom!'], #
-                 ['Program', 'Gratuitous Explosions'], ['Series', 'Nova']],
-        title: 'Nova; Gratuitous Explosions; Kaboom!; 3-2-1',
+        titles_sort: 'Nova; Gratuitous Explosions; 3-2-1; Kaboom!',
+        titles: [['Series', 'Nova'], ['Program', 'Gratuitous Explosions'], #
+                 ['Episode Number', '3-2-1'], ['Episode', 'Kaboom!']],
+        title: 'Nova; Gratuitous Explosions; 3-2-1; Kaboom!',
         exhibits: [],
         descriptions: ['Best episode ever!'],
         instantiations: [PBCore::Instantiation.new('Moving Image', 'should be ignored!'),


### PR DESCRIPTION
Fixes #508.

(Some misgivings about this, but it might be good enough. If we stick with this approach, there will be some follow-up to clean-up: #569.)