### PR TITLE
Fix #594: No longer index or look for full title string. 

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -237,8 +237,9 @@ class PBCore # rubocop:disable Metrics/ClassLength
 
   def text
     ignores = [:text, :to_solr, :contribs, :img_src, :media_srcs, :captions_src, 
-               :rights_code, :access_level, :access_types, :titles_sort, :ci_ids, 
-               :instantiations, :outside_url]
+               :rights_code, :access_level, :access_types, 
+               :titles_sort, :title, # Covered by #titles 
+               :ci_ids, :instantiations, :outside_url]
     @text ||= (PBCore.instance_methods(false) - ignores)
               .reject { |method| method =~ /\?$/ } # skip booleans
               .map { |method| send(method) } # method -> value

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -108,8 +108,7 @@ describe 'Validated and plain PBCore' do
             'Album', 'Uncataloged', '2000-01-01', #
             'Series', 'Nova', 'Program', 'Gratuitous Explosions', # 
             'Episode Number', '3-2-1', 'Episode', 'Kaboom!', #
-            'Nova; Gratuitous Explosions; 3-2-1; Kaboom!', '1234', #
-            'AAPB ID', 'somewhere else', '5678', #
+            '1234', 'AAPB ID', 'somewhere else', '5678', #
             'WGBH', 'Boston', 'Massachusetts', #
             'Moving Image', '1:23:45'],
           'titles' => ['Nova', 'Gratuitous Explosions', '3-2-1', 'Kaboom!'],


### PR DESCRIPTION
(All the components are still indexed.)

#570 and #568 clash: In one we decided no longer to put the full title on the results page, in the other we started using the "title" method for the full title, instead of just the first portion. When combined, these cause the test failure.

@afred : If you could prioritize this: we have test failures on master right now. Thanks!