### PR TITLE
Description removed because duplicate 604

### DIFF
--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -176,8 +176,6 @@ class Cleaner # rubocop:disable Metrics/ClassLength
     seen_values = Set.new
     ['/pbcoreTitle', '/pbcoreDescription', '/pbcoreRightsSummary/rightsSummary', #
         '/pbcoreInstantiation/instantiationIdentifier'].each { |name|
-        
-      
       match(doc, name) { |node|
         if seen_values.include?(node.text)
           Cleaner.delete(node)
@@ -185,6 +183,10 @@ class Cleaner # rubocop:disable Metrics/ClassLength
           seen_values.add(node.text)
         end
       }
+    }
+    
+    match(doc, '[not(pbcoreDescription)]') {
+      raise 'No pbcoreDescription remains after removal of duplicate values'
     }
     
     # formatting:

--- a/spec/fixtures/pbcore/dirty-no-fix-duplicate-description-removed-error.txt
+++ b/spec/fixtures/pbcore/dirty-no-fix-duplicate-description-removed-error.txt
@@ -1,0 +1,1 @@
+No pbcoreDescription remains after removal of duplicate values

--- a/spec/fixtures/pbcore/dirty-no-fix-duplicate-description-removed.xml
+++ b/spec/fixtures/pbcore/dirty-no-fix-duplicate-description-removed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pbcoreDescriptionDocument 
+    xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd' 
+    xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' 
+    xsi:xmlns='http://www.w3.org/2001/XMLSchema-instance' 
+    xmlns:xsi='xsi'><!-- Root attributes are screwy in AMS export. -->
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/301-xxxxx</pbcoreIdentifier>
+  <pbcoreTitle titleType="Series">Writers Forum</pbcoreTitle>
+  <pbcoreDescription descriptionType="duplicate to be removed">Writers Forum</pbcoreDescription>
+</pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/dirty-no-fix-multi-aai-id-error.txt
+++ b/spec/fixtures/pbcore/dirty-no-fix-multi-aai-id-error.txt
@@ -1,12 +1,12 @@
 Method validation errors: '#exhibits' failed: Expected 1 match for '/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]'; got 2
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `tap'
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `xpath'
+/.../AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
+/.../AAPB2/app/models/xml_backed.rb:9:in `tap'
+/.../AAPB2/app/models/xml_backed.rb:9:in `xpath'
 '#id' failed: Expected 1 match for '/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]'; got 2
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `tap'
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `xpath'
+/.../AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
+/.../AAPB2/app/models/xml_backed.rb:9:in `tap'
+/.../AAPB2/app/models/xml_backed.rb:9:in `xpath'
 '#captions_src' failed: Expected 1 match for '/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]'; got 2
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `tap'
-/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `xpath'
+/.../AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
+/.../AAPB2/app/models/xml_backed.rb:9:in `tap'
+/.../AAPB2/app/models/xml_backed.rb:9:in `xpath'

--- a/spec/fixtures/pbcore/dirty-no-fix-multi-aai-id-error.txt
+++ b/spec/fixtures/pbcore/dirty-no-fix-multi-aai-id-error.txt
@@ -1,0 +1,12 @@
+Method validation errors: '#exhibits' failed: Expected 1 match for '/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]'; got 2
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `tap'
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `xpath'
+'#id' failed: Expected 1 match for '/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]'; got 2
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `tap'
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `xpath'
+'#captions_src' failed: Expected 1 match for '/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]'; got 2
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:11:in `block in xpath'
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `tap'
+/Users/chuck_mccallum/starting/AAPB2/app/models/xml_backed.rb:9:in `xpath'

--- a/spec/fixtures/pbcore/dirty-no-fix-skeleton-error.txt
+++ b/spec/fixtures/pbcore/dirty-no-fix-skeleton-error.txt
@@ -1,0 +1,1 @@
+undefined method `next_sibling=' for nil:NilClass

--- a/spec/scripts/cleaner_spec.rb
+++ b/spec/scripts/cleaner_spec.rb
@@ -32,9 +32,17 @@ describe Cleaner do
       it "chokes on #{name}" do
         cleaner = Cleaner.new
         dirty = File.read(path_dirty)
+        expected = File.read(path_dirty.gsub('.xml','-error.txt'))
 
         # Error could occur either in cleaning or validation; We don't care.
-        expect { ValidatedPBCore.new(cleaner.clean(dirty, name)) }.to raise_error
+        begin 
+          ValidatedPBCore.new(cleaner.clean(dirty, name))
+          fail('Expected an error')
+        rescue => e
+          expect(e.message).to eq expected
+        end
+        # This could be shorter, but the eq matcher gives us a diff that we don't get from
+        #   expect { ValidatedPBCore.new(cleaner.clean(dirty, name)) }.to raise_error(expected)
       end
     end
   end

--- a/spec/scripts/cleaner_spec.rb
+++ b/spec/scripts/cleaner_spec.rb
@@ -39,7 +39,9 @@ describe Cleaner do
           ValidatedPBCore.new(cleaner.clean(dirty, name))
           fail('Expected an error')
         rescue => e
-          expect(e.message).to eq expected
+          expect(e.message.gsub(/^\s*\/.*AAPB2\//, '')).
+            to eq expected.gsub(/^\s*\/.*AAPB2\//, '')
+          # Full paths need to be cleaned up so that they match on Travis.
         end
         # This could be shorter, but the eq matcher gives us a diff that we don't get from
         #   expect { ValidatedPBCore.new(cleaner.clean(dirty, name)) }.to raise_error(expected)


### PR DESCRIPTION
This still errors on these records, but the error message is much more clear.

Going to say that this fixes #604
```
perl -pne 's/.+\///;s/,.+//' ~/xml-bad.txt | \
  xargs ruby scripts/download_clean_ingest.rb \
  --same-mount --stdout-log --skip-sitemap --ids
```
All the ones that were bad fall in this category.

@sroosa : I know I talked with you and proposed just loosening the check. Right now, I'm pretty confident this is what we want for the long term... but if we temporarily want a different behavior just to get the records ingested, let's start a new track for that.