### PR TITLE
If media type is "other", just use the audio player

### DIFF
--- a/app/views/catalog/_player.erb
+++ b/app/views/catalog/_player.erb
@@ -8,31 +8,27 @@
 </script>
 
 <%= 
-  if @pbcore.video? || @pbcore.audio?
-    @pbcore.media_srcs.map do |media_src|
-      media = @pbcore.video? ? 'video' : 'audio'
-      content_tag(media, 'class' => 'video-js vjs-default-skin', 
-                  controls: true,
-                  oncontextmenu: 'return false;', 
-                  preload: 'none', width: 400, height: 300,
-                  poster: @pbcore.img_src, 'data-setup' => '{}') do %>
+  @pbcore.media_srcs.map do |media_src|
+    media = @pbcore.video? ? 'video' : 'audio'
+    content_tag(media, 'class' => 'video-js vjs-default-skin', 
+                controls: true,
+                oncontextmenu: 'return false;', 
+                preload: 'none', width: 400, height: 300,
+                poster: @pbcore.img_src, 'data-setup' => '{}') do %>
 
-        <source src="<%= media_src %>" type='<%= @pbcore.video? ? 'video/mp4' : 'audio/mp3' %>' />
+      <source src="<%= media_src %>" type='<%= @pbcore.video? ? 'video/mp4' : 'audio/mp3' %>' />
 
-        <% if @pbcore.captions_src %>    
-          <track kind="captions" src="<%= @pbcore.captions_src %>" srclang="en" label="English" default></track>
-        <% end %>
+      <% if @pbcore.captions_src %>    
+        <track kind="captions" src="<%= @pbcore.captions_src %>" srclang="en" label="English" default></track>
+      <% end %>
 
-        <p class="vjs-no-js">
-          To play this <%= media %> please enable JavaScript, and consider upgrading to a web browser that 
-          <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 <%= media %></a>.
-        </p>
+      <p class="vjs-no-js">
+        To play this <%= media %> please enable JavaScript, and consider upgrading to a web browser that 
+        <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 <%= media %></a>.
+      </p>
 
-        
-        <%
-      end
-    end.join().html_safe()
-  else
-    logger.error("#{@pbcore.id} is neither video nor audio.")
-  end
+
+      <%
+    end
+  end.join().html_safe()
 %>


### PR DESCRIPTION
@caseyedavis12 : Is this ok, or should ingest fail if we have ci id, and "other" media type, as we do here? http://americanarchive.org/catalog/cpb-aacip_27-gx44q7r549.pbcore:
```xml
<pbcoreIdentifier source="Sony Ci">ad23e7dbefd346c49fa37de4c26f1515</pbcoreIdentifier>
...
<instantiationMediaType>other</instantiationMediaType>
```

I'm comfortable with this: downside:
- Facet info wrong; icon missing

upside:
- save a lot of recataloging work

Fix #697. @afred : please review.