### PR TITLE
Caption 699

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -219,7 +219,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
         pre_existing.parent.elements.delete(pre_existing)
       end
       caption_body = caption_response.body
-      REXML::XPath.match(doc_with_caption_flag, '/*/pbcoreInstantiation').last.next_sibling = 
+      REXML::XPath.match(doc_with_caption_flag, '/*/pbcoreInstantiation').last.next_sibling.next_sibling = 
         REXML::Document.new(
           "<pbcoreAnnotation annotationType='#{CAPTIONS_ANNOTATION}'>" +
           caption_url + '</pbcoreAnnotation>'

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -97,7 +97,11 @@ class PBCore # rubocop:disable Metrics/ClassLength
     @media_srcs ||= (1..ci_ids.count).map { |part| "/media/#{id}?part=#{part}" }
   end
   def captions_src
-    @captions_src ||= "/captions/#{id}.txt" if video?
+    @captions_src ||= begin
+      s3_id = id.gsub('_','-')
+      base = 'https://s3.amazonaws.com/americanarchive.org/captions'
+      "#{base}/#{s3_id}/#{s3_id}.srt1.srt" if video?
+    end
     # TODO: "CC" icon will show for all videos, even if caption isn't actually available.
   end
   def img_src

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -8,6 +8,7 @@ require_relative 'xml_backed'
 require_relative 'pb_core_instantiation'
 require_relative 'pb_core_name_role_affiliation'
 require_relative 'organization'
+require_relative '../../lib/formatter'
 
 class PBCore # rubocop:disable Metrics/ClassLength
   # rubocop:disable Style/EmptyLineBetweenDefs
@@ -226,11 +227,9 @@ class PBCore # rubocop:disable Metrics/ClassLength
         )
     end
     
-    xml_holder = []
-    doc_with_caption_flag.write(xml_holder)
     {
       'id' => id,
-      'xml' => xml_holder.join(),
+      'xml' => Formatter.instance.format(doc_with_caption_flag),
 
       # constrained searches:
       'text' => text + [caption_body].select { |optional| optional },

--- a/lib/formatter.rb
+++ b/lib/formatter.rb
@@ -1,0 +1,16 @@
+require 'rexml/document'
+
+class Formatter
+  include Singleton
+
+  def initialize
+    @formatter = REXML::Formatters::Pretty.new(2)
+    @formatter.compact = true
+  end
+
+  def format(doc)
+    output = []
+    @formatter.write(doc, output)
+    output.join
+  end
+end

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -1,6 +1,7 @@
 require 'rexml/document'
 require 'set'
 require_relative '../../app/models/vocab_map'
+require_relative '../../lib/formatter'
 
 class Cleaner # rubocop:disable Metrics/ClassLength
   attr_reader :match
@@ -196,11 +197,7 @@ class Cleaner # rubocop:disable Metrics/ClassLength
 
     # formatting:
 
-    formatter = REXML::Formatters::Pretty.new(2)
-    formatter.compact = true
-    output = []
-    formatter.write(doc, output)
-    output.join('').sub("<\?xml version='1\.0' encoding='UTF-8'\?> \n", '')
+    Formatter.instance.format(doc).sub("<\?xml version='1\.0' encoding='UTF-8'\?> \n", '')
     # XML declaration seems to be output with trailing space, which makes tests just a bit annoying.
     # Just stripping it should be fine.
   end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -326,7 +326,10 @@ describe 'Catalog' do
     it 'works' do
       visit '/catalog/1234.pbcore'
       expect(page.status_code).to eq(200)
-      expect(page.source).to eq(File.read(Rails.root + 'spec/fixtures/pbcore/clean-MOCK.xml'))
+      # Don't worry about whitespace text nodes.
+      expect(page.source.gsub(/>\s+</, '><')).to eq(
+        File.read(Rails.root + 'spec/fixtures/pbcore/clean-MOCK.xml').gsub(/>\s+</, '><')
+      )
       expect(page.response_headers['Content-Type']).to eq('text/xml; charset=utf-8')
     end
   end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -326,10 +326,7 @@ describe 'Catalog' do
     it 'works' do
       visit '/catalog/1234.pbcore'
       expect(page.status_code).to eq(200)
-      # Don't worry about whitespace text nodes.
-      expect(page.source.gsub(/>\s+</, '><')).to eq(
-        File.read(Rails.root + 'spec/fixtures/pbcore/clean-MOCK.xml').gsub(/>\s+</, '><')
-      )
+      expect(page.source).to eq(File.read(Rails.root + 'spec/fixtures/pbcore/clean-MOCK.xml'))
       expect(page.response_headers['Content-Type']).to eq('text/xml; charset=utf-8')
     end
   end

--- a/spec/fixtures/pbcore/clean-MOCK.xml
+++ b/spec/fixtures/pbcore/clean-MOCK.xml
@@ -45,6 +45,7 @@
     <instantiationGenerations>Proxy</instantiationGenerations>
     <instantiationDuration>1:23:45</instantiationDuration>
   </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType='Captions URL'>https://s3.amazonaws.com/americanarchive.org/captions/1234/1234.srt1.srt</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='organization'>WGBH</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
   <pbcoreAnnotation annotationType='Outside URL'>http://www.wgbh.org/</pbcoreAnnotation>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -95,7 +95,10 @@ describe 'Validated and plain PBCore' do
       assertions = {
         to_solr: {
           'id' => '1234',
-          'xml' => pbc_xml,
+          'xml' => pbc_xml.gsub(
+            "</pbcoreInstantiation>\n  <pbcoreAnnotation",
+            "</pbcoreInstantiation><pbcoreAnnotation annotationType='Captions URL'>https://s3.amazonaws.com/americanarchive.org/captions/1234/1234.srt1.srt</pbcoreAnnotation>\n  <pbcoreAnnotation"
+          ),
           'episode_number_titles' => ['3-2-1'],
           'episode_titles' => ['Kaboom!'],
           'program_titles' => ['Gratuitous Explosions'],
@@ -110,7 +113,8 @@ describe 'Validated and plain PBCore' do
             'Episode Number', '3-2-1', 'Episode', 'Kaboom!', #
             '1234', 'AAPB ID', 'somewhere else', '5678', #
             'WGBH', 'Boston', 'Massachusetts', #
-            'Moving Image', '1:23:45'],
+            'Moving Image', '1:23:45',
+            "1\n00:00:00,000 --> 00:00:20,000\nTest suite checks this string\n"],
           'titles' => ['Nova', 'Gratuitous Explosions', '3-2-1', 'Kaboom!'],
           'title' => 'Nova; Gratuitous Explosions; 3-2-1; Kaboom!',
           'contribs' => ['Larry', 'Stooges', 'Curly', 'Stooges', 'Moe', 'Stooges'],
@@ -146,7 +150,7 @@ describe 'Validated and plain PBCore' do
         ci_ids: ['a-32-digit-hex', 'another-32-digit-hex'],
         media_srcs: ['/media/1234?part=1', '/media/1234?part=2'],
         img_src: "#{AAPB::S3_BASE}/thumbnail/1234.jpg",
-        captions_src: '/captions/1234.txt',
+        captions_src: 'https://s3.amazonaws.com/americanarchive.org/captions/1234/1234.srt1.srt',
         organization_pbcore_name: 'WGBH',
         organization: Organization.find_by_pbcore_name('WGBH'),
         outside_url: 'http://www.wgbh.org/',

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -90,15 +90,10 @@ describe 'Validated and plain PBCore' do
     end
 
     describe 'full' do
-      pbc = PBCore.new(pbc_xml)
-
       assertions = {
         to_solr: {
           'id' => '1234',
-          'xml' => pbc_xml.gsub(
-            "</pbcoreInstantiation>\n  <pbcoreAnnotation",
-            "</pbcoreInstantiation><pbcoreAnnotation annotationType='Captions URL'>https://s3.amazonaws.com/americanarchive.org/captions/1234/1234.srt1.srt</pbcoreAnnotation>\n  <pbcoreAnnotation"
-          ),
+          'xml' => pbc_xml,
           'episode_number_titles' => ['3-2-1'],
           'episode_titles' => ['Kaboom!'],
           'program_titles' => ['Gratuitous Explosions'],
@@ -167,6 +162,8 @@ describe 'Validated and plain PBCore' do
         contributors: [PBCoreNameRoleAffiliation.new('contributor', 'Curly', 'bald', 'Stooges')],
         publishers: [PBCoreNameRoleAffiliation.new('publisher', 'Moe', 'hair', 'Stooges')]
       }
+
+      pbc = PBCore.new(pbc_xml)
 
       assertions.each do |method, value|
         it "\##{method} method works" do


### PR DESCRIPTION
Fix #699.
@afred: Please review. This got more complicated than I was thinking at first, but I think it's the right direction. The center of the complexity is `to_solr`: This is only called at index time, so I think it's the right place to ping s3 so that we can tell (1) whether the captions even exist, and (2) what the content is, but only for the purpose of indexing.

I think this will be of increasing utility as we have transcript-y things which don't belong in the pbcore, but which should be indexed for retrieval.