### PR TITLE
No org counts

### DIFF
--- a/app/views/catalog/_organization_facet.erb
+++ b/app/views/catalog/_organization_facet.erb
@@ -19,7 +19,6 @@
     %>
       <li>
         <%= render_facet_item('organization', OpenStruct.new(value: option.value)) %>
-        <span class="facet-count"><%= option.hits || 0 %></span>
       </li>
     <% end %>
   <% end %>


### PR DESCRIPTION
Fix #702: The number of numbers was just overwhelming, and the tag-ex logic may have confused the user. This is simpler, though we are sharing less information than we were.

![screen shot 2015-09-15 at 3 33 15 pm](https://cloud.githubusercontent.com/assets/730388/9887785/73747352-5bbf-11e5-9516-8d6196488150.png)
