### PR TITLE
Records from Mississippi should be given clean IDs now.

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -76,6 +76,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
     @id ||= xpath('/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]').tr('/_', '_/')
     # AAPB IDs, frustratingly, include slashes. We don't expect to see underscore,
     # so swap these two for a loss-less mapping. May revisit.
+    # TODO: Maybe this should be in cleaner?
   end
   SONY_CI = 'Sony Ci'
   def ids

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -50,6 +50,11 @@ class Cleaner # rubocop:disable Metrics/ClassLength
     match(doc, '/pbcoreIdentifier[not(@source)]') do |node|
       node.attributes['source'] = 'unknown'
     end
+    
+    match(doc, '/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]') do |node|
+      node.text = node.text.gsub(/cpb-aacip./, 'cpb-aacip/')
+      # Particularly for records from Mississippi that have a '-' instead of '/'
+    end
 
     # pbcoreTitle:
 

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-essence-track.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd">
     <pbcoreIdentifier source="WNYC Archive Catalog">72208</pbcoreIdentifier>
     <pbcoreIdentifier source="pbcore XML database UUID">986dd7a4-fd14-4e51-ab8b-3dbea66fd504</pbcoreIdentifier>
-    <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/80-12893j6c</pbcoreIdentifier>
+    <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip-80-12893j6c</pbcoreIdentifier>
     <pbcoreTitle titleType="Episode">Judd Hirsch</pbcoreTitle>
     <pbcoreTitle titleType="Series">This is My Music</pbcoreTitle>
     <pbcoreTitle titleType="Collection">WQXR</pbcoreTitle>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-language.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-language.xml
@@ -3,7 +3,7 @@
   <pbcoreAssetType>Element</pbcoreAssetType>
   <pbcoreIdentifier source="IPTV Barcode">IPTVUS-0006712</pbcoreIdentifier>
   <pbcoreIdentifier source="NOLA">OOI</pbcoreIdentifier>
-  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/37-31cjt2qs</pbcoreIdentifier>
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip!37-31cjt2qs</pbcoreIdentifier>
   <pbcoreTitle titleType="Element">Dr. Norman Borlaug</pbcoreTitle>
   <pbcoreTitle titleType="Element">B-Roll</pbcoreTitle>
   <pbcoreSubject>Norman Borlaug</pbcoreSubject>


### PR DESCRIPTION
Fix #798. @afred?

Thought about moving the `.tr('/_', '_/')` out of PBCore. If we were starting from scratch I would put everything in Cleaner, but at this point it would mean changing each of the clean fixtures, and it would make all of the live data is slightly out of date... 

If we do it this way, instead, I think the right way to think about it is that there is the real AACIP ID which has a slash, or ought to, and the cleaner fixes it up that way, and there is a distinct AAPB ID for website use which has an underscore instead. Seem ok?