### PR TITLE
More robust against weird chars in id list

### DIFF
--- a/scripts/download_clean_ingest.rb
+++ b/scripts/download_clean_ingest.rb
@@ -78,7 +78,7 @@ class DownloadCleanIngest
 
       when ID_FILES
         fail ParamsError.new unless args.count >= 1
-        ids = args.map { |id_file| File.readlines(id_file).map { |line| line.strip } }.flatten
+        ids = args.map { |id_file| File.readlines(id_file) }.flatten
         target_dirs = download(ids: ids)
 
       when DIRS

--- a/scripts/lib/downloader.rb
+++ b/scripts/lib/downloader.rb
@@ -46,6 +46,7 @@ class Downloader
       dirname ||= "#{now}_by_ids_#{opts[:ids].size}"
       mkdir_and_cd(dirname, opts[:is_same_mount])
       opts[:ids].each do |id|
+        id = id.gsub(/[^[:ascii:]]/,'').gsub(/[^[:print:]]/,'')
         short_id = id.sub(/.*[_\/]/, '')
         content = if opts[:is_just_reindex]
                     $LOG.info("Query solr for #{id}")

--- a/spec/scripts/downloader_spec.rb
+++ b/spec/scripts/downloader_spec.rb
@@ -27,7 +27,8 @@ describe Downloader, not_on_travis: true do
   end
 
   it 'downloads by id' do
-    dir = Downloader.download_to_directory_and_link(ids: ['cpb-aacip/17-00000qrv'], is_same_mount: true)
+    dir = Downloader.download_to_directory_and_link(ids: [0.chr+'cpb-aacip/17-00000qrv'+160.chr], is_same_mount: true)
+    # 0.chr and 160.chr to make sure we strip weird characters.
     expect(dir).to match(/\d{4}-\d{2}-\d{2}.*_by_ids_1/)
     files = Dir["#{dir}/*.pbcore.zip"]
     expect(files.map { |f| f.sub(/.*\//, '') }).to eq(['17-00000qrv.pbcore.zip'])


### PR DESCRIPTION
@afred: Kevin got an ID list containing an xA0, non-breaking space. That same file works now with this PR. Also moved the cleaning deeper, so it works for either --ids or --id-files.