### PR TITLE
Collapse orgs facet, even when selected.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -74,7 +74,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'organization', sort: 'index', solr_params: { 'facet.limit' => -1 },
                            # Default is 100, but we have more orgs than that. -1 means no limit.
                                            tag: 'org', ex: 'org,state',
-                                           partial: 'organization_facet'
+                                           partial: 'organization_facet',
+                                           collapse: :force
                            # Display all, even when one is selected.
     config.add_facet_field 'year', sort: 'index', range: true,
                                    message: 'Cataloging in progress: Only 1/3 of AAPB records are currently dated.'

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -118,3 +118,15 @@ module Blacklight::FacetsHelperBehavior
       # END patch
   end
 end
+
+module Blacklight::FacetsHelperBehavior
+  def should_collapse_facet? facet_field
+    # Before:
+    #   !facet_field_in_params?(facet_field.field) && facet_field.collapse
+    # BEGIN patch
+    facet_field.collapse == :force || (
+      !facet_field_in_params?(facet_field.field) && facet_field.collapse
+    )
+    # END patch
+  end
+end


### PR DESCRIPTION
 yay(?) monkey-patching. @afred? I'm not super confident about our diagnosis of the underlying problem, or of this UI hack to fix it, but it's not unreasonable either. I'm pretty confident that this is not something BL gives us out of the box, judging by the docs.
```
  # Determine whether a facet should be rendered as collapsed or not.
  #   - if the facet is 'active', don't collapse
  #   - if the facet is configured to collapse (the default), collapse
  #   - if the facet is configured not to collapse, don't collapse
```



Fix #816.