### PR TITLE
In the cleaning phase, transpose articles. Fix #819.

### DIFF
--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -226,6 +226,7 @@ class Cleaner # rubocop:disable Metrics/ClassLength
   end
 
   def self.clean_title(title)
+    title = title.gsub(/^(.*), (a|an|the)$/i, '\2 \1')
     if title =~ /[A-Z]/ && title =~ /[a-z]/
       title # No change, if mix of upper and lower.
     else

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -238,7 +238,7 @@ describe 'Catalog' do
         describe 'relevance sorting' do
           assertions = [
             ['Iowa', ['Touchstone 108', 'Musical Encounter; 116; Music for Fun', 'Dr. Norman Borlaug; B-Roll']],
-            ['art', ['Scheewe Art Workshop', 'Unknown', 'A Sorting Test: 100']],
+            ['art', ['The Scheewe Art Workshop', 'Unknown', 'A Sorting Test: 100']],
             ['John', ['World Cafe; Larry Kane On John Lennon 2005', 'Dr. Norman Borlaug; B-Roll']]
           ]
           assertions.each do |query, titles|
@@ -299,7 +299,7 @@ describe 'Catalog' do
                 ['Series: Nova', 'Program: Gratuitous Explosions', 'Episode Number: 3-2-1', 'Episode: Kaboom!', 'Date: 2000-01-01', 'Organization: WGBH'],
                 ['Title: Podcast Release Form', 'Organization: KXCI Community Radio'],
                 ['Series: Reading Aloud', 'Program: MacLeod: The Palace G', 'Organization: WGBH'],
-                ['Title: Scheewe Art Workshop', 'Organization: Detroit Public Televi'],
+                ['Title: The Scheewe Art Works', 'Organization: Detroit Public Televi'],
                 ['Program: The Sorting Test: 1', 'Organization: WUSF'],
                 ['Program: SORTING Test: 2', 'Organization: Detroit Public Televi'],
                 ['Program: A Sorting Test: 100', 'Organization: WNYC'],

--- a/spec/fixtures/pbcore/clean-bad-title-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type.xml
@@ -2,7 +2,7 @@
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source='WTVS DATABASE ID'>WTVS000613</pbcoreIdentifier>
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_240-12893cp0</pbcoreIdentifier>
-  <pbcoreTitle titleType='Title'>Scheewe Art Workshop</pbcoreTitle>
+  <pbcoreTitle titleType='Title'>The Scheewe Art Workshop</pbcoreTitle>
   <pbcoreDescription>TAPE 5</pbcoreDescription>
   <pbcoreInstantiation>
     <instantiationIdentifier source='WTVS DATABASE ID'>WTVS000613</instantiationIdentifier>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-title-type.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-title-type.xml
@@ -2,7 +2,7 @@
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source="WTVS DATABASE ID">WTVS000613</pbcoreIdentifier>
   <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/240-12893cp0</pbcoreIdentifier>
-  <pbcoreTitle titleType="Original">SCHEEWE ART WORKSHOP</pbcoreTitle>
+  <pbcoreTitle titleType="Original">SCHEEWE ART WORKSHOP, THE</pbcoreTitle>
   <pbcoreDescription>TAPE 5</pbcoreDescription>
   <pbcoreInstantiation>
     <instantiationIdentifier source="WTVS DATABASE ID">WTVS000613</instantiationIdentifier>

--- a/spec/scripts/cleaner_spec.rb
+++ b/spec/scripts/cleaner_spec.rb
@@ -51,6 +51,7 @@ describe Cleaner do
 
   describe '#clean_title' do
     {
+      'The redundant trailing article, A' => 'A The redundant trailing article',
       'No change if a mix of UPPER and lower' => 'No change if a mix of UPPER and lower',
       'guesses some: xkcd, cnn, rdf, wgbh, dc' => 'Guesses Some: XKCD, CNN, RDF, WGBH, DC',
       'HARD CODED: CEO, LA, MIT, UC-DAVIS, WETA' => 'Hard Coded: CEO, LA, MIT, UC-Davis, WETA',


### PR DESCRIPTION
@afred? Did not go with my initial intuition after all: We want to keep the model clean, and ad hoc cleaning heuristics like this should not clutter the model.