### PR TITLE
Fix broken affixed navigation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ gem 'therubyracer', :platforms => :ruby
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
+
+# A package that helps fix jquery code that breaks due to turbolinks.
+gem 'jquery-turbolinks'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.2)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
@@ -272,6 +275,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jettywrapper (~> 1.7)
   jquery-rails
+  jquery-turbolinks
   passenger
   pry
   pry-nav

--- a/app/assets/javascripts/affix.js
+++ b/app/assets/javascripts/affix.js
@@ -145,7 +145,7 @@
   // AFFIX DATA-API
   // ==============
 
-  $(window).on('load', function () {
+  $(document).ready(function () {
     $('[data-spy="affix"]').each(function () {
       var $spy = $(this)
       var data = $spy.data()

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,8 +11,8 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require jquery_ujs
-//= require turbolinks
 //
 // Required by Blacklight
 //= require blacklight/blacklight
@@ -22,3 +22,4 @@
 // this:
 //= require 'blacklight_range_limit'
 
+//= require turbolinks


### PR DESCRIPTION
* Adds jquery-turbolinks gem, which, resolves issues with jquery events not
  firing due to turbolinks black magic.
* Requires changing the event to which Affix plugin is applied.
* Closes #611.