### PR TITLE
Reverts ID conversion

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -75,6 +75,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
   def id
     # Solr IDs need to have "cpb-aacip_" instead of "cpb_aacip/" for proper lookup in Solr.
     # Some IDs (e.g. Mississippi) may have "cpb-aacip-", but that's OK.
+    # TODO: https://github.com/WGBH/AAPB2/issues/870
     @id ||= xpath('/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]').gsub("cpb-aacip/", 'cpb-aacip_')
   end
   SONY_CI = 'Sony Ci'
@@ -103,6 +104,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
     @img_src ||=
       case [media_type, digitized?]
       when [MOVING_IMAGE, true]
+        # TODO: https://github.com/WGBH/AAPB2/issues/870
         # Mississipie IDs have dashes, but they cannot for image URLs on S3. All S3 image URLs use "cpb-aacip_".
         "#{AAPB::S3_BASE}/thumbnail/#{id.gsub(/cpb-aacip-/, "cpb-aacip_")}.jpg"
       when [MOVING_IMAGE, false]

--- a/scripts/lib/cleaner.rb
+++ b/scripts/lib/cleaner.rb
@@ -50,11 +50,6 @@ class Cleaner # rubocop:disable Metrics/ClassLength
     match(doc, '/pbcoreIdentifier[not(@source)]') do |node|
       node.attributes['source'] = 'unknown'
     end
-    
-    match(doc, '/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]') do |node|
-      node.text = node.text.gsub(/cpb-aacip./, 'cpb-aacip_')
-      # Particularly for records from Mississippi that have a '-' instead of '/'
-    end
 
     # pbcoreTitle:
 

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -334,6 +334,7 @@ describe 'Catalog' do
       # #text is only used for #to_solr, so it's private...
       # so we need the #send to get at it.
       target.send(:text).each do |field|
+        field.gsub!("cpb-aacip_", 'cpb-aacip/') if field =~ /^cpb-aacip/
         expect(page).to have_text(field)
       end
     end
@@ -353,7 +354,7 @@ describe 'Catalog' do
     end
     
     it 'apologizes if no access' do
-      visit '/catalog/cpb-aacip_80-12893j6c'
+      visit '/catalog/cpb-aacip-80-12893j6c'
       # No need to click through
       expect_all_the_text('clean-bad-essence-track.xml')
       expect(page).to have_text('This content has not been digitized.')

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -334,7 +334,7 @@ describe 'Catalog' do
       # #text is only used for #to_solr, so it's private...
       # so we need the #send to get at it.
       target.send(:text).each do |field|
-        field.gsub!("cpb-aacip_", 'cpb-aacip/') if field =~ /^cpb-aacip/
+        field.gsub!("cpb-aacip_", 'cpb-aacip/') if field =~ /^cpb-aacip/ # TODO: Remove when we sort out ID handling.
         expect(page).to have_text(field)
       end
     end

--- a/spec/fixtures/pbcore/clean-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/clean-bad-essence-track.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='WNYC Archive Catalog'>72208</pbcoreIdentifier>
   <pbcoreIdentifier source='pbcore XML database UUID'>986dd7a4-fd14-4e51-ab8b-3dbea66fd504</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/80-12893j6c</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip-80-12893j6c</pbcoreIdentifier>
   <pbcoreTitle titleType='Collection'>WQXR</pbcoreTitle>
   <pbcoreTitle titleType='Series'>This is My Music</pbcoreTitle>
   <pbcoreTitle titleType='Episode'>Judd Hirsch</pbcoreTitle>

--- a/spec/fixtures/pbcore/clean-bad-essence-track.xml
+++ b/spec/fixtures/pbcore/clean-bad-essence-track.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='WNYC Archive Catalog'>72208</pbcoreIdentifier>
   <pbcoreIdentifier source='pbcore XML database UUID'>986dd7a4-fd14-4e51-ab8b-3dbea66fd504</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_80-12893j6c</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/80-12893j6c</pbcoreIdentifier>
   <pbcoreTitle titleType='Collection'>WQXR</pbcoreTitle>
   <pbcoreTitle titleType='Series'>This is My Music</pbcoreTitle>
   <pbcoreTitle titleType='Episode'>Judd Hirsch</pbcoreTitle>

--- a/spec/fixtures/pbcore/clean-bad-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-language.xml
@@ -2,7 +2,7 @@
   <pbcoreAssetType>Raw Footage</pbcoreAssetType>
   <pbcoreIdentifier source='IPTV Barcode'>IPTVUS-0006712</pbcoreIdentifier>
   <pbcoreIdentifier source='NOLA'>OOI</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_37-31cjt2qs</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/37-31cjt2qs</pbcoreIdentifier>
   <pbcoreTitle titleType='Raw Footage'>Dr. Norman Borlaug</pbcoreTitle>
   <pbcoreTitle titleType='Raw Footage'>B-Roll</pbcoreTitle>
   <pbcoreSubject>Norman Borlaug</pbcoreSubject>

--- a/spec/fixtures/pbcore/clean-bad-media-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-media-type.xml
@@ -1,5 +1,5 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_192-1937pxnq</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/192-1937pxnq</pbcoreIdentifier>
   <pbcoreTitle titleType='Title'>Podcast Release Form</pbcoreTitle>
   <pbcoreDescription>
     Podcast Release Form Bajo Turbato Performers/Instruments: Chris Black,

--- a/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
+++ b/spec/fixtures/pbcore/clean-bad-relation-and-language.xml
@@ -3,7 +3,7 @@
   <pbcoreAssetDate dateType='Created'>1990-07-27</pbcoreAssetDate>
   <pbcoreAssetDate dateType='Date'>1991-07-27</pbcoreAssetDate>
   <pbcoreIdentifier source='MAVIS Title Number'>6875</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_151-2z12n4zx85</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/151-2z12n4zx85</pbcoreIdentifier>
   <pbcoreTitle titleType='Title'>From Bessie Smith to Bruce Springsteen</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreRelation>

--- a/spec/fixtures/pbcore/clean-bad-title-type-substring.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type-substring.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Program</pbcoreAssetType>
   <pbcoreIdentifier source='WPBS-TV'>Four Decades of Dedication: The 40th Anniversary Special</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_254-92g79p08</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/254-92g79p08</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>Four Decades of Dedication: The 40th Anniversary Special</pbcoreTitle>
   <pbcoreTitle titleType='Title'>Handles missing titleTypes, too.</pbcoreTitle>
   <pbcoreSubject>WPBS 40 years</pbcoreSubject>

--- a/spec/fixtures/pbcore/clean-bad-title-type.xml
+++ b/spec/fixtures/pbcore/clean-bad-title-type.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source='WTVS DATABASE ID'>WTVS000613</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_240-12893cp0</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/240-12893cp0</pbcoreIdentifier>
   <pbcoreTitle titleType='Title'>The Scheewe Art Workshop</pbcoreTitle>
   <pbcoreDescription>TAPE 5</pbcoreDescription>
   <pbcoreInstantiation>

--- a/spec/fixtures/pbcore/clean-basic.xml
+++ b/spec/fixtures/pbcore/clean-basic.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd' xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
   <!-- Root attributes are screwy in AMS export. -->
   <pbcoreIdentifier source='WERU Prog List'>WRF028</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_301-60cvdtx8</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/301-60cvdtx8</pbcoreIdentifier>
   <pbcoreTitle titleType='Series'>Writers Forum</pbcoreTitle>
   <pbcoreTitle titleType='Program'>WRF-09/13/07</pbcoreTitle>
   <pbcoreDescription descriptionType='Description'>Writers Forum</pbcoreDescription>

--- a/spec/fixtures/pbcore/clean-coverage-type-lc.xml
+++ b/spec/fixtures/pbcore/clean-coverage-type-lc.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Raw Footage</pbcoreAssetType>
   <pbcoreIdentifier source='Maryland Public Television'>18037</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_394-62f7m6kq</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/394-62f7m6kq</pbcoreIdentifier>
   <pbcoreTitle titleType='Raw Footage'>MSOM Field Tape - BUG 12</pbcoreTitle>
   <pbcoreDescription>MSOM Field Tape - BUG 11 C. Miller part 2</pbcoreDescription>
   <pbcoreGenre annotation='genre'>Magazine</pbcoreGenre>

--- a/spec/fixtures/pbcore/clean-empty-coverage-type.xml
+++ b/spec/fixtures/pbcore/clean-empty-coverage-type.xml
@@ -2,7 +2,7 @@
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source='WXPN Barcode'>7006</pbcoreIdentifier>
   <pbcoreIdentifier source='WXPN'>Martin Luther King, Jr.</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_155-859cp21j</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/155-859cp21j</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>World Cafe</pbcoreTitle>
   <pbcoreTitle titleType='Segment'>1997-01-20 Sat/Mon</pbcoreTitle>
   <pbcoreTitle titleType='Segment'>Martin Luther King, Jr. 1997</pbcoreTitle>

--- a/spec/fixtures/pbcore/clean-empty-description.xml
+++ b/spec/fixtures/pbcore/clean-empty-description.xml
@@ -2,7 +2,7 @@
   <pbcoreIdentifier source='MARS Asset Record ID'>A_1LLRRAJ8TCCKZCH</pbcoreIdentifier>
   <pbcoreIdentifier source='MARS Source Creation Order'>275829</pbcoreIdentifier>
   <pbcoreIdentifier source='WGBH Old File Number'>P03649,W01263</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_15-042rd7dg</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/15-042rd7dg</pbcoreIdentifier>
   <pbcoreTitle titleType='Series'>Reading Aloud</pbcoreTitle>
   <pbcoreTitle titleType='Program'>MacLeod: The Palace Guard</pbcoreTitle>
   <pbcoreDescription/>

--- a/spec/fixtures/pbcore/clean-every-title-is-episode-number.xml
+++ b/spec/fixtures/pbcore/clean-every-title-is-episode-number.xml
@@ -4,7 +4,7 @@
   <pbcoreIdentifier source='IPTV Barcode'>IPTVUS-0002773</pbcoreIdentifier>
   <pbcoreIdentifier source='NOLA'>MLER</pbcoreIdentifier>
   <pbcoreIdentifier source='Old Tape Number'>4E11</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_37-16c2fsnr</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/37-16c2fsnr</pbcoreIdentifier>
   <pbcoreIdentifier source='Sony Ci'>1243412ece4946348f7b1b7715247cb5</pbcoreIdentifier>
   <pbcoreTitle titleType='Episode Number'>Musical Encounter</pbcoreTitle>
   <pbcoreTitle titleType='Episode Number'>116</pbcoreTitle>

--- a/spec/fixtures/pbcore/clean-exhibit.xml
+++ b/spec/fixtures/pbcore/clean-exhibit.xml
@@ -2,7 +2,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Program</pbcoreAssetType>
   <pbcoreAssetDate dateType='Created'>1981-12-05</pbcoreAssetDate>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_111-21ghx7d6</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/111-21ghx7d6</pbcoreIdentifier>
   <pbcoreIdentifier source='Arkansas Educational Television Network (AETN) Production Video Library (PVL)'>534</pbcoreIdentifier>
   <pbcoreIdentifier source='Sony Ci'>4d09bc902a5b45f1a9ead4fce04c807e</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>15th Anniversary Show</pbcoreTitle>

--- a/spec/fixtures/pbcore/clean-has-rights-already.xml
+++ b/spec/fixtures/pbcore/clean-has-rights-already.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Program</pbcoreAssetType>
   <pbcoreIdentifier source='KUOW Puget Sound Public Radio'>weekdayb</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_358-01bk3s1z</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/358-01bk3s1z</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>Ask Governor Chris Gregoire</pbcoreTitle>
   <pbcoreSubject source='Internal'>Puget Sound, transportation, the economy, trade, education</pbcoreSubject>
   <pbcoreDescription>

--- a/spec/fixtures/pbcore/clean-no-contributor.xml
+++ b/spec/fixtures/pbcore/clean-no-contributor.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='Asset ID'>1018184</pbcoreIdentifier>
   <pbcoreIdentifier source='Interlochen Center for the Arts'>43825000002120</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_300-23vt4h5m</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/300-23vt4h5m</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>unknown</pbcoreTitle>
   <pbcoreDescription>Location: Interlochen Public Radio Archives</pbcoreDescription>
   <pbcoreDescription>National Music Camp | program file no. 95</pbcoreDescription>

--- a/spec/fixtures/pbcore/clean-no-creator.xml
+++ b/spec/fixtures/pbcore/clean-no-creator.xml
@@ -1,6 +1,6 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='NOLA Code'>NONOLA001817 [SDBA]</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_168-0966t590</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/168-0966t590</pbcoreIdentifier>
   <pbcoreTitle titleType='Series'>Gvsports</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcorePublisher>

--- a/spec/fixtures/pbcore/clean-no-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-identifier-source.xml
@@ -2,7 +2,7 @@
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source='WXPN'>Larry Kane</pbcoreIdentifier>
   <pbcoreIdentifier source='unknown'>John Lennon</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_155-17crjgpf</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/155-17crjgpf</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>World Cafe</pbcoreTitle>
   <pbcoreTitle titleType='Segment'>Larry Kane On John Lennon 2005</pbcoreTitle>
   <pbcoreSubject source='PBS'>MUSIC</pbcoreSubject>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-location-mediaType.xml
@@ -1,5 +1,5 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_293-10wpzhr8</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/293-10wpzhr8</pbcoreIdentifier>
   <pbcoreTitle titleType='Series'>Askc: Ask Congress</pbcoreTitle>
   <pbcoreTitle titleType='Episode'>#508</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>

--- a/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-identifier-source.xml
@@ -1,7 +1,7 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Segment</pbcoreAssetType>
   <pbcoreIdentifier source='WXPN Barcode'>Howard Kramer</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_155-451g1rsx</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/155-451g1rsx</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>World Cafe</pbcoreTitle>
   <pbcoreTitle titleType='Segment'>Howard Kramer 2004</pbcoreTitle>
   <pbcoreSubject>Interview</pbcoreSubject>

--- a/spec/fixtures/pbcore/clean-no-instantiation.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation.xml
@@ -1,6 +1,6 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='unknown'>1863</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_304-579s52qf</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/304-579s52qf</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>The Sorting Test: 1</pbcoreTitle>
   <pbcoreDescription>No description available</pbcoreDescription>
   <pbcoreAnnotation annotationType='last_modified'>2013-06-02 06:28:16</pbcoreAnnotation>

--- a/spec/fixtures/pbcore/clean-no-publisher.xml
+++ b/spec/fixtures/pbcore/clean-no-publisher.xml
@@ -1,6 +1,6 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreAssetType>Segment</pbcoreAssetType>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_55-644qs820</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/55-644qs820</pbcoreIdentifier>
   <pbcoreTitle titleType='Title'>Dry Spell</pbcoreTitle>
   <pbcoreDescription>
     Content: The film is the story of a man who cannot express his emotions of

--- a/spec/fixtures/pbcore/clean-no-relation-type.xml
+++ b/spec/fixtures/pbcore/clean-no-relation-type.xml
@@ -1,5 +1,5 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_16-q814m91v76</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/16-q814m91v76</pbcoreIdentifier>
   <pbcoreIdentifier source='Episode Number'>108</pbcoreIdentifier>
   <pbcoreIdentifier source='http://www.americanmediaarchive.org'>IPTV-2010012514124212630108429072317516514806564295896</pbcoreIdentifier>
   <pbcoreIdentifier source='IPTV-AAPP'>IPTV-002</pbcoreIdentifier>

--- a/spec/fixtures/pbcore/clean-rename-attribute.xml
+++ b/spec/fixtures/pbcore/clean-rename-attribute.xml
@@ -1,6 +1,6 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='WNYC Archive Catalog'>43226</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_80-w6693t63</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/80-w6693t63</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'>A Sorting Test: 100</pbcoreTitle>
   <pbcoreDescription>
     Lopate Show regulars Alvin and Larry Ubell, the gurus of how-to, take your

--- a/spec/fixtures/pbcore/clean-sorting.xml
+++ b/spec/fixtures/pbcore/clean-sorting.xml
@@ -1,6 +1,6 @@
 <pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd'>
   <pbcoreIdentifier source='WTVS DATABASE ID'>WTVS009483</pbcoreIdentifier>
-  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip_240-07tmpw1x</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/240-07tmpw1x</pbcoreIdentifier>
   <pbcoreTitle titleType='Program'># &quot;SORTING&quot; Test: 2</pbcoreTitle>
   <pbcoreDescription>#5+7</pbcoreDescription>
   <pbcoreInstantiation>

--- a/spec/fixtures/pbcore/dirty-yes-fix-bad-language.xml
+++ b/spec/fixtures/pbcore/dirty-yes-fix-bad-language.xml
@@ -3,7 +3,7 @@
   <pbcoreAssetType>Element</pbcoreAssetType>
   <pbcoreIdentifier source="IPTV Barcode">IPTVUS-0006712</pbcoreIdentifier>
   <pbcoreIdentifier source="NOLA">OOI</pbcoreIdentifier>
-  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip!37-31cjt2qs</pbcoreIdentifier>
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/37-31cjt2qs</pbcoreIdentifier>
   <pbcoreTitle titleType="Element">Dr. Norman Borlaug</pbcoreTitle>
   <pbcoreTitle titleType="Element">B-Roll</pbcoreTitle>
   <pbcoreSubject>Norman Borlaug</pbcoreSubject>


### PR DESCRIPTION
Puts it back into PBCore model, instead of Cleaner.
Needed to fix ID chaos.
Closes #868