### PR TITLE
Fix line break regression.

### DIFF
--- a/app/views/override/contact-us.md
+++ b/app/views/override/contact-us.md
@@ -6,15 +6,15 @@ We would love to hear from you! If you have general questions or comments about 
 collection, or want to share information on the stories you find in the 
 collection, you can reach us at [aapb_notifications@wgbh.org](aapb_notifications@wgbh.org) or by mail.
 
-### Library of Congress Mailing Address:</br>
-Alan Gevinson</br>
-Library of Congress</br>
-Packard Campus for Audio Visual Conservation</br>
-19053 Mt. Pony Rd.</br>
-Culpeper, Virginia 22701-7551</br>
+### Library of Congress Mailing Address:
+Alan Gevinson<br/>
+Library of Congress<br/>
+Packard Campus for Audio Visual Conservation<br/>
+19053 Mt. Pony Rd.<br/>
+Culpeper, Virginia 22701-7551<br/>
 
-### WGBH Mailing Address:</br>
-Karen Cariani</br>
-WGBH Educational Foundation</br>
-One Guest Street</br>
-Boston, Massachusetts 02135</br>
+### WGBH Mailing Address:
+Karen Cariani<br/>
+WGBH Educational Foundation<br/>
+One Guest Street<br/>
+Boston, Massachusetts 02135<br/>


### PR DESCRIPTION
@afred: Fix regression from 9c010c5a7cf. Github rendering is subtly different from the redcarpet renderer we're using... It might be possible to use the github renderer? Filed https://github.com/WGBH/cmless/issues/12. Fix #873