### PR TITLE
Redacted media

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -9,9 +9,12 @@ class MediaController < ApplicationController
     if can?(:play, pbcore) && (current_user.aapb_referer? || current_user.embed?)
       ci = SonyCiBasic.new(credentials_path: Rails.root + 'config/ci.yml')
       # OAuth credentials expire: otherwise it would make sense to cache this instance.
-      redirect_to ci.download(pbcore.ci_ids[(params['part'].to_i || 1) - 1])
-    else
-      render nothing: true, status: :unauthorized
+      ci_id = pbcore.ci_ids[(params['part'].to_i || 1) - 1]
+      if can?(:play, ci_id)
+        redirect_to ci.download(pbcore.ci_ids[(params['part'].to_i || 1) - 1])
+        return
+      end
     end
+    render nothing: true, status: :unauthorized
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,6 +8,11 @@ class Ability
       (user.onsite? && (pbcore.public? || pbcore.protected?)) || # Comment out for developing TOS features.
       (user.usa? && !user.bot? && user.affirmed_tos? && pbcore.public?)
     end
+    
+    can :play, String do |ci_id|
+      # Relies on checks also being made against the PBCore object.
+      !ci_id.protected? || user.onsite?
+    end
 
     cannot :skip_tos, PBCore do |pbcore|
       !user.onsite? && # Comment out for developing TOS features.

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -112,7 +112,11 @@ class PBCore # rubocop:disable Metrics/ClassLength
     end
   end
   def media_srcs
-    @media_srcs ||= (1..ci_ids.count).map { |part| "/media/#{id}?part=#{part}" }
+    @media_srcs ||= ci_ids.each_with_index.map do |ci_id, zero_index|
+      "/media/#{id}?part=#{zero_index+1}"
+      # TODO: read 'protected?' on ci_id and set a similar attribute here,
+      # so it can be read downstream.
+    end
   end
   CAPTIONS_ANNOTATION = 'Captions URL'
   def captions_src

--- a/spec/fixtures/pbcore/access-level-public-protected-media.xml
+++ b/spec/fixtures/pbcore/access-level-public-protected-media.xml
@@ -1,0 +1,5 @@
+<pbcoreDescriptionDocument xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html'>
+  <!-- Realistically, there would be another Ci they do have access to. -->
+  <pbcoreIdentifier source='Sony Ci' annotation='protected'>this-makes-it-digitized</pbcoreIdentifier>
+  <pbcoreAnnotation annotationType='Level of User Access'>Online Reading Room</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-MOCK.xml
+++ b/spec/fixtures/pbcore/clean-MOCK.xml
@@ -4,7 +4,7 @@
   <pbcoreIdentifier source='http://americanarchiveinventory.org'>1234</pbcoreIdentifier>
   <pbcoreIdentifier source='somewhere else'>5678</pbcoreIdentifier>
   <pbcoreIdentifier source='Sony Ci'>a-32-digit-hex</pbcoreIdentifier>
-  <pbcoreIdentifier source='Sony Ci'>another-32-digit-hex</pbcoreIdentifier>
+  <pbcoreIdentifier source='Sony Ci' annotation='protected'>another-32-digit-hex</pbcoreIdentifier>
   <pbcoreTitle titleType='Series'>Nova</pbcoreTitle>
   <pbcoreTitle titleType='Program'>Gratuitous Explosions</pbcoreTitle>
   <pbcoreTitle titleType='Episode Number'>3-2-1</pbcoreTitle>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -58,7 +58,7 @@ describe 'Validated and plain PBCore' do
 
       it 'rejects undigitized w/ "Level of User Access"' do
         invalid_pbcore = pbc_xml.gsub(
-          /<pbcoreIdentifier source='Sony Ci'>[^<]+<[^>]+>/,
+          /<pbcoreIdentifier source='Sony Ci'[^<]+<[^>]+>/,
           '')
         expect { ValidatedPBCore.new(invalid_pbcore) }.to(
           raise_error(/Should not have "Level of User Access" annotation if not digitized/))
@@ -66,7 +66,7 @@ describe 'Validated and plain PBCore' do
 
       it 'rejects "Outside URL" if not explicitly ORR' do
         invalid_pbcore = pbc_xml.gsub( # First make it un-digitized
-          /<pbcoreIdentifier source='Sony Ci'>[^<]+<[^>]+>/,
+          /<pbcoreIdentifier source='Sony Ci'[^<]+<[^>]+>/,
           '').gsub( # Then remove access
             /<pbcoreAnnotation annotationType='Level of User Access'>[^<]+<[^>]+>/,
             '')
@@ -183,6 +183,10 @@ describe 'Validated and plain PBCore' do
 
       it 'tests everthing' do
         expect(assertions.keys.sort).to eq(PBCore.instance_methods(false).sort)
+      end
+      
+      it 'has extra info on ci_ids' do
+        expect(pbc.ci_ids.map { |ci_id| ci_id.protected? }).to eq([false, true])
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,6 +82,7 @@ describe User do
     
     examples = {
       public:    PBCore.new(File.read('./spec/fixtures/pbcore/access-level-public.xml')),
+      pub_pro:   PBCore.new(File.read('./spec/fixtures/pbcore/access-level-public-protected-media.xml')),
       protected: PBCore.new(File.read('./spec/fixtures/pbcore/access-level-protected.xml')),
       private:   PBCore.new(File.read('./spec/fixtures/pbcore/access-level-private.xml')),
       all:       PBCore.new(File.read('./spec/fixtures/pbcore/access-level-all.xml'))
@@ -89,12 +90,14 @@ describe User do
     
     onsite_access = {
       public:     { play: true,  skip_tos: true},
+      pub_pro:    { play: true,  skip_tos: true},
       protected:  { play: true,  skip_tos: true},
       private:    { play: false, skip_tos: true},
       all:        { play: false, skip_tos: true},
     }
     no_access = {
       public:     { play: false, skip_tos: true},
+      pub_pro:    { play: false, skip_tos: true},
       protected:  { play: false, skip_tos: true},
       private:    { play: false, skip_tos: true},
       all:        { play: false, skip_tos: true},
@@ -123,6 +126,7 @@ describe User do
       OpenStruct.new(onsite?: false, affirmed_tos?: false, usa?: true, bot?: false) =>
         {
           public:     { play: false, skip_tos: false},
+          pub_pro:    { play: false, skip_tos: false},
           protected:  { play: false, skip_tos: true},
           private:    { play: false, skip_tos: true},
           all:        { play: false, skip_tos: true},
@@ -130,6 +134,7 @@ describe User do
       OpenStruct.new(onsite?: false, affirmed_tos?: true, usa?: true, bot?: false) =>
         {
           public:     { play: true,  skip_tos: true},
+          pub_pro:    { play: true,  skip_tos: true},
           protected:  { play: false, skip_tos: true},
           private:    { play: false, skip_tos: true},
           all:        { play: false, skip_tos: true},


### PR DESCRIPTION
@afred: This isn't complete, but how does this approach seem to you? Basically, the ci_ids, and eventually the media_srcs, will carry an extra bit of metadata about the visibility of that particular Ci asset. It keeps the surface interfaces the same at the cost of more complicated objects being passed underneath.

Alternatively, we could make pairs of methods where now we have only one:
`ci_ids` -> `protected_ci_ids` and `unprotected_ci_ids`
`media_srcs` -> `protected_media_srcs` and `unprotected_media_srcs`

I'm leaning towards the latter approach, now, but not really sure...