### PR TITLE
Mods

### DIFF
--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -6,8 +6,8 @@ class OaiController < ApplicationController
     @verb = params.delete(:verb)
     fail("Unsupported verb: #{@verb}") unless @verb == 'ListRecords'
 
-    @metadata_prefix = params.delete(:metadataPrefix) || 'pbcore'
-    fail("Unsupported metadataPrefix: #{@metadata_prefix}") unless @metadata_prefix == 'pbcore'
+    @metadata_prefix = params.delete(:metadataPrefix) || 'mods'
+    fail("Unsupported metadataPrefix: #{@metadata_prefix}") unless @metadata_prefix == 'mods'
 
     resumption_token = params.delete(:resumptionToken) || '0'
     fail("Unsupported resumptionToken: #{resumption_token}") unless resumption_token =~ /^\d*$/
@@ -29,7 +29,8 @@ class OaiController < ApplicationController
         Record.new(
           d['id'],
           d['timestamp'],
-          d['xml'].gsub('<?xml version="1.0" encoding="UTF-8"?>', '').strip)
+          PBCore.new(d['xml'])
+        )
       end
 
     # Not ideal: they'll need to go past the end.

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -78,6 +78,9 @@ class PBCore # rubocop:disable Metrics/ClassLength
     # TODO: https://github.com/WGBH/AAPB2/issues/870
     @id ||= xpath('/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]').gsub("cpb-aacip/", 'cpb-aacip_')
   end
+  def uri
+    @uri ||= 'http://americanarchive.org/catalog/' + id
+  end
   SONY_CI = 'Sony Ci'
   def ids
     @ids ||= begin

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -78,9 +78,6 @@ class PBCore # rubocop:disable Metrics/ClassLength
     # TODO: https://github.com/WGBH/AAPB2/issues/870
     @id ||= xpath('/*/pbcoreIdentifier[@source="http://americanarchiveinventory.org"]').gsub("cpb-aacip/", 'cpb-aacip_')
   end
-  def uri
-    @uri ||= 'http://americanarchive.org/catalog/' + id
-  end
   SONY_CI = 'Sony Ci'
   def ids
     @ids ||= begin

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -18,7 +18,7 @@
                     pb = record.pbcore
                     Nokogiri::XML::Builder.new do |x|
                       x.mods(xmlns: 'http://www.loc.gov/mods/v3') {
-                        x.identifier(pb.uri, type: 'uri')
+                        x.identifier('http://americanarchive.org/catalog/' + pb.id, type: 'uri')
                         x.titleInfo(usage: 'primary') {
                           x.title(pb.title)
                         }

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -22,20 +22,42 @@
                         x.titleInfo(usage: 'primary') {
                           x.title(pb.title)
                         }
-                        pb.creators.each do |creator|
-                          x.name(creator.name) {
+                        (pb.creators + pb.contributors).each do |person|
+                          x.name(person.name) {
                             x.role {
-                              x.roleTerm(creator.role)
+                              x.roleTerm(person.role)
                             }
                           }
                         end
-                        pb.contributors.each do |contributor|
-                          x.name(contributor.name) {
-                            x.role {
-                              x.roleTerm(contributor.role)
-                            }
-                          }
+                        x.typeOfResource(
+                          pb.video? ? 'moving image' : 'sound recording'
+                        )
+                        x.physicalDescription('digitized other analog')
+                        (pb.genres + pb.topics).each do |term|
+                          x.genre(term)
                         end
+                        x.originInfo {
+                          pb.publishers.each do |publisher|
+                            x.publisher(publisher.name)
+                          end
+                          x.dateCreated(pb.asset_date)
+                        }
+                        x.physicalDescription {
+                          x.extent(pb.duration)
+                        }
+                        x.abstract(pb.descriptions.join("\n"))
+                        pb.subjects.each do |subj|
+                          x.subject(subj)
+                        end
+                        x.relatedItem(type: 'host') {
+                          x.titleInfo {
+                            x.title('American Archive of Public Broadcasting')
+                          }  
+                        }
+                        x.location {
+                          x.physicalLocation(pb.organization.short_name)
+                        }
+                        x.accessCondition('Contact host institution for more information.', type: 'use and reproduction')
                       }
                     end.to_xml.sub('<?xml version="1.0"?>','').html_safe
                     %>

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" 
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+         xmlns:mods="http://www.loc.gov/mods/v3"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
          http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
@@ -13,7 +14,31 @@
                     <datestamp><%= record.date %></datestamp>
                 </header>
                 <metadata>
-                    <%= record.pbcore.html_safe %>
+                    <%=
+                    pb = record.pbcore
+                    Nokogiri::XML::Builder.new do |x|
+                      x.mods(xmlns: 'http://www.loc.gov/mods/v3') {
+                        x.identifier(pb.uri, type: 'uri')
+                        x.titleInfo(usage: 'primary') {
+                          x.title(pb.title)
+                        }
+                        pb.creators.each do |creator|
+                          x.name(creator.name) {
+                            x.role {
+                              x.roleTerm(creator.role)
+                            }
+                          }
+                        end
+                        pb.contributors.each do |contributor|
+                          x.name(contributor.name) {
+                            x.role {
+                              x.roleTerm(contributor.role)
+                            }
+                          }
+                        end
+                      }
+                    end.to_xml.sub('<?xml version="1.0"?>','').html_safe
+                    %>
                 </metadata>
             </record>
         <% end %>

--- a/spec/features/oai_spec.rb
+++ b/spec/features/oai_spec.rb
@@ -12,11 +12,9 @@ describe 'OAI-PMH' do
     expect { REXML::Document.new(page.body) }.not_to raise_error
     [
       '<OAI-PMH', # Followed by NS
-      '<request verb="ListRecords" metadataPrefix="pbcore">http://openvault.wgbh.org/oai.xml</request>',
+      '<request verb="ListRecords" metadataPrefix="mods">http://openvault.wgbh.org/oai.xml</request>',
       '<ListRecords>',
-      '<identifier>cpb-aacip_37-16c2fsnr</identifier>',
-      '<pbcoreDescriptionDocument', # Followed by NS
-      "<pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/37-16c2fsnr</pbcoreIdentifier>"
+      '<identifier type="uri">http://americanarchive.org/catalog/1234</identifier>'
     ].each do |s|
       expect(page.body).to match s
     end


### PR DESCRIPTION
@afred? The BPL folks had sent Casie a field mapping spreadsheet to fill out, and she in turn passed it to me... but there's a bit of work that's required to get from our pbcore xml to their fields, but a lot less if you can go from our pbcore object. More work will certainly be required.

(Not a huge fan of haml-ish approaches, in general, but this is so data-heavy that I thought a builder was better than balancing all the tags and opening and closing `<%=` and `%>` all over the place.)