### PR TITLE
Fixes specs for media urls

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -9,7 +9,7 @@ class MediaController < ApplicationController
     if can?(:play, pbcore) && (current_user.aapb_referer? || current_user.embed?)
       ci = SonyCiBasic.new(credentials_path: Rails.root + 'config/ci.yml')
       # OAuth credentials expire: otherwise it would make sense to cache this instance.
-      redirect_to ci.download(pbcore.ci_ids[(params['part'].to_i || 1) - 1])
+      redirect_to ci.download(pbcore.ci_ids[(params['part'] || 1).to_i - 1])
     else
       render nothing: true, status: :unauthorized
     end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -329,6 +329,10 @@ describe 'Catalog' do
   end
 
   describe '#show' do
+    before do
+      page.driver.options[:headers] = { 'REMOTE_ADDR' => '198.147.175.1' }
+    end
+
     def expect_all_the_text(fixture_name)
       target = PBCore.new(File.read('spec/fixtures/pbcore/' + fixture_name))
       # #text is only used for #to_solr, so it's private...


### PR DESCRIPTION
Fixes a bug in media controller.
Refactors spec for tesing media url redirection.
Adds a test for media url redirection given referer of popuparchive.com.
Causes User#aapb_referer? to return false in case of missing or malformed referer value.