### PR TITLE
Chrome transcript error goes away

### DIFF
--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -6,6 +6,7 @@
                 controls: true,
                 oncontextmenu: 'return false;', 
                 preload: 'none', width: AAPB::PLAYER_WIDTH, height: AAPB::PLAYER_HEIGHT,
+                crossorigin: 'anonymous',
                 poster: @pbcore.img_src) do %>
 
       <source src="<%= media_src %>" type='<%= @pbcore.video? ? 'video/mp4' : 'audio/mp3' %>' />


### PR DESCRIPTION
but still no display of transcript.

Maybe VTT instead of SRT would fix that? Fix #1005. @foo4thought ?