### PR TITLE
Citations. 

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -212,6 +212,29 @@
     </dl>
   <% end %>
 
+  <dl>
+    <% url = "http://americanarchive.org/catalog/#{@pbcore.id}" %>
+    <% today = Date.today.to_formatted_s(:long) %>
+    <% org = @pbcore.organization.short_name_html.gsub(/<[^>]*>/, '').html_safe + ', American Archive of Public Broadcasting (WGBH and the Library of Congress), Boston, MA and Washington, DC' %>
+    <dt>Citation</dt>
+    <dd><em>Chicago</em>: 
+      &ldquo;<%= @pbcore.title %>,&rdquo;
+      <%= @pbcore.date + ',' if @pbcore.asset_date %> 
+      <%= org %>, 
+      accessed <%= today %>, 
+      <%= url %>.</dd>
+    <dd><em>MLA</em>:
+      &ldquo;<%= @pbcore.title %>.&rdquo;
+      <%= @pbcore.date + '.' if @pbcore.asset_date %>
+      <%= org %>.
+      Web. <%= today %>. 
+      &lt;<%= url %>&gt;.</dd>
+    <dd><em>APA</em>:
+      <%= @pbcore.title %>.
+      Boston, MA: <%= org %>.
+      Retrieved from <%= url %></dd>
+  </dl>
+      
 <% end %>
   
 <%= render partial: 'shared/title_sidebar_main', 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -219,13 +219,13 @@
     <dt>Citation</dt>
     <dd><em>Chicago</em>: 
       &ldquo;<%= @pbcore.title %>,&rdquo;
-      <%= @pbcore.date + ',' if @pbcore.asset_date %> 
+      <%= @pbcore.asset_date + ',' if @pbcore.asset_date %> 
       <%= org %>, 
       accessed <%= today %>, 
       <%= url %>.</dd>
     <dd><em>MLA</em>:
       &ldquo;<%= @pbcore.title %>.&rdquo;
-      <%= @pbcore.date + '.' if @pbcore.asset_date %>
+      <%= @pbcore.asset_date + '.' if @pbcore.asset_date %>
       <%= org %>.
       Web. <%= today %>. 
       &lt;<%= url %>&gt;.</dd>


### PR DESCRIPTION
No particular confidence that this format is correct. Right now, I don't think we want to a adopt a button-to-fold-down idiom: The scroll bar does a perfectly good job of hiding information unless you want to see it. Fix #688. @foo4thought ?
<img width="505" alt="screen shot 2016-07-07 at 2 08 13 pm" src="https://cloud.githubusercontent.com/assets/730388/16664042/7b9452fc-444c-11e6-8677-67683ace1712.png">

