### PR TITLE
moved label lower

### DIFF
--- a/config/vocab-maps/title-type-map.yml
+++ b/config/vocab-maps/title-type-map.yml
@@ -6,7 +6,6 @@
 # Final line is a fall-through.
 
 !omap
-  label: Label
   collection: Collection
   series: Series
   program: Program
@@ -24,4 +23,5 @@
   b-roll: Raw Footage
   b roll: Raw Footage
   album: Album
+  label: Label
   '': Title


### PR DESCRIPTION
Moved where "Label" fell on the vocab mapping, so that when the titles are concatenated in the search results display, Label comes towards the end, rather than at the beginning of the title string. 