### PR TITLE
Fixes CORS issue with video tracks

### DIFF
--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -6,7 +6,7 @@
                 controls: true,
                 oncontextmenu: 'return false;', 
                 preload: 'none', width: AAPB::PLAYER_WIDTH, height: AAPB::PLAYER_HEIGHT,
-                crossorigin: 'anonymous',
+                crossorigin: 'with-credentials',
                 poster: @pbcore.img_src) do %>
 
       <source src="<%= media_src %>" type='<%= @pbcore.video? ? 'video/mp4' : 'audio/mp3' %>' />


### PR DESCRIPTION
Changes value of `crossorigin` property from "anonymous" to "with-credentials",
which allows the caption file to be served from S3, and also sends the cookie
containing the session ID so that the MediaController can successfully retrieve
the user's session, which has the correct value for indicating the user has
agreed to the TOS, which allows the video to play.