### PR TITLE
1035: Cleans Out Downloads dir after Ingest

### DIFF
--- a/scripts/download_clean_ingest.rb
+++ b/scripts/download_clean_ingest.rb
@@ -28,9 +28,9 @@ class DownloadCleanIngest
   end
 
   def download(opts)
-    [Downloader.download_to_directory_and_link(
+    [Downloader.new(
       { is_just_reindex: @is_just_reindex }.merge(opts)
-    )]
+    ).run]
   end
 
   def initialize(argv)

--- a/scripts/lib/downloader.rb
+++ b/scripts/lib/downloader.rb
@@ -16,77 +16,46 @@ class Downloader
   # ie, this not sensitive.
   $LOG ||= NullLogger.new
 
-  def initialize(since)
-    @since = since
-    since.match(/(\d{4})(\d{2})(\d{2})/).tap do |match|
-      raise("Expected YYYYMMDD, not '#{since}'") unless
-        match &&
-        match[1].to_i < 3000 &&
-        match[2].to_i.instance_eval { |m| (1 <= m) && (m <= 12) } &&
-        match[3].to_i.instance_eval { |d| (1 <= d) && (d <= 31) }
-    end
+  def initialize(opts = {})
+    check_expected_keys(opts)
+
+    since = if opts.key?(:days)
+              (Time.now - opts[:days] * 24 * 60 * 60).strftime('%Y%m%d')
+            else
+              '20000101' #ie, beginning of time.
+            end
+    check_since(since)
+
+    @options = opts
+    @options[:since] = since
+    @options[:dirname] = Time.now.strftime('%F_%T.%6N')
   end
 
-  def self.download_to_directory_and_link(opts = {})
+  def run
+    mkdir_and_cd(@options[:dirname])
 
-    raise("Unexpected keys: #{opts}") unless Set.new(opts.keys).subset?(
-      Set[
-        :days, :page, :ids, :query, # modes
-        :is_just_reindex # flags
-      ])
-    now = Time.now.strftime('%F_%T.%6N')
-    dirname ||= "#{now}"
-
-    if opts[:query]
-      q = QueryMaker.translate(opts[:query])
-      $LOG.info("Query solr for #{opts[:query]}")
-      opts[:ids] = RSolr.connect(url: 'http://localhost:8983/solr/').get('select', params: {
-                                                                           q: q, fl: 'id', rows: MAX_ROWS })['response']['docs'].map { |doc| doc['id'] }
-      raise("Got back more than #{MAX_ROWS} from query") if opts[:ids].size > MAX_ROWS
+    if @options[:query]
+      process_query(@options[:query])
     end
-    if opts[:ids]
-      mkdir_and_cd(dirname)
-      opts[:ids].each do |id|
-        id = id.gsub(/[^[:ascii:]]/, '').gsub(/[^[:print:]]/, '')
-        short_id = id.sub(/.*[_\/]/, '')
-        content = if opts[:is_just_reindex]
-                    $LOG.info("Query solr for #{id}")
-                    # TODO: hostname and corename from config?
-                    Solr.instance.connect
-                        .get('select', params: {
-                               qt: 'document', id: id
-                             })['response']['docs'][0]['xml']
-                  else
-                    url = "https://ams.americanarchive.org/xml/pbcore/key/#{KEY}/guid/#{short_id}"
-                    $LOG.info("Downloading #{url}")
-                    Downloader.http_get(url)
-        end
 
-        Zipper.write("#{short_id}.pbcore", content)
-      end
+    if @options[:ids]
+      download_ids_to_directory(@options[:ids])
     else
-      opts[:page] ||= 1 # API is 1-indexed, but also returns page 1 results for page 0.
-      since = if opts[:days]
-                (Time.now - opts[:days] * 24 * 60 * 60).strftime('%Y%m%d')
-              else
-                '20000101' # ie, beginning of time.
-              end
-
-      mkdir_and_cd(dirname)
-      downloader = Downloader.new(since)
-      downloader.download_to_directory(opts[:page])
+      @options[:page] ||= 1 # API is 1-indexed, but also returns page 1 results for page 0.
+      download_pages_to_directory(@options[:page])
     end
-    # calls rm_rf on old download directories
-    clean_downloads_directory(dirname)
 
+    clean_downloads_directory(@options[:dirname])
     Dir.pwd
   end
 
-  def self.http_get(url)
+  private
+
+  def http_get(url)
     URI.parse(url).read(read_timeout: 240, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
   end
 
-  def self.mkdir_and_cd(name)
+  def mkdir_and_cd(name)
     Dir.chdir(Rails.root)
     path = "tmp/downloads/#{name}"
     FileUtils.mkdir_p(path)
@@ -101,7 +70,7 @@ class Downloader
     Dir.chdir(link_name)
   end
 
-  def self.clean_downloads_directory(dirname)
+  def clean_downloads_directory(dirname)
     old_dirs = []
     path = "#{Rails.root}/tmp/downloads"
 
@@ -112,8 +81,8 @@ class Downloader
     FileUtils.rm_rf(old_dirs)
   end
 
-  def download_to_directory(start_page)
-    download(start_page) do |collection, page|
+  def download_pages_to_directory(start_page)
+    download_by_page(start_page) do |collection, page|
       name = "page-#{page}.pbcore"
 
       # Need code to clean out directory
@@ -123,16 +92,61 @@ class Downloader
     end
   end
 
-  private
+  def check_expected_keys(options)
+    raise("Unexpected keys: #{options}") unless Set.new(options.keys).subset?(
+      Set[
+        :days, :page, :ids, :query, # modes
+        :is_just_reindex # flags
+    ])
+  end
 
-  def download(page)
+  def check_since(since)
+    since.match(/(\d{4})(\d{2})(\d{2})/).tap do |match|
+      raise("Expected YYYYMMDD, not '#{since}'") unless
+        match &&
+        match[1].to_i < 3000 &&
+        match[2].to_i.instance_eval { |m| (1 <= m) && (m <= 12) } &&
+        match[3].to_i.instance_eval { |d| (1 <= d) && (d <= 31) }
+    end
+  end
+
+  def process_query(query)
+    q = QueryMaker.translate(query)
+    $LOG.info("Query solr for #{query}")
+
+    @options[:ids] = RSolr.connect(url: 'http://localhost:8983/solr/').get('select', params: {
+                                                                         q: q, fl: 'id', rows: MAX_ROWS })['response']['docs'].map { |doc| doc['id'] }
+    raise("Got back more than #{MAX_ROWS} from query") if @options[:ids].size > MAX_ROWS
+  end
+
+  def download_ids_to_directory(ids)
+    ids.each do |id|
+      id = id.gsub(/[^[:ascii:]]/, '').gsub(/[^[:print:]]/, '')
+      short_id = id.sub(/.*[_\/]/, '')
+      content = if @options[:is_just_reindex]
+                  $LOG.info("Query solr for #{id}")
+                  # TODO: hostname and corename from config?
+                  Solr.instance.connect
+                      .get('select', params: {
+                             qt: 'document', id: id
+                           })['response']['docs'][0]['xml']
+                else
+                  url = "https://ams.americanarchive.org/xml/pbcore/key/#{KEY}/guid/#{short_id}"
+                  $LOG.info("Downloading #{url}")
+                  http_get(url)
+      end
+      Zipper.write("#{short_id}.pbcore", content)
+    end
+  end
+
+  def download_by_page(page)
     loop do
-      url = "https://ams.americanarchive.org/xml/pbcore/key/#{KEY}/modified_date/#{@since}/page/#{page}"
+      url = "https://ams.americanarchive.org/xml/pbcore/key/#{KEY}/modified_date/#{@options[:since]}/page/#{page}"
       content = nil
       until content
         begin
           $LOG.info("Trying #{url}")
-          content = Downloader.http_get(url)
+          content = http_get(url)
         rescue Net::ReadTimeout
           $LOG.warn('Timeout. Retrying in 10...')
           sleep 10

--- a/scripts/lib/downloader.rb
+++ b/scripts/lib/downloader.rb
@@ -101,6 +101,17 @@ class Downloader
     Dir.chdir(link_name)
   end
 
+  def self.clean_downloads_directory(dirname)
+    old_dirs = []
+    path = "#{Rails.root}/tmp/downloads"
+
+    Dir.glob("#{path}/**").each do |dir|
+      old_dirs << dir unless dir == "#{path}/#{dirname}" || dir == "#{path}/LATEST"
+    end
+
+    FileUtils.rm_rf(old_dirs)
+  end
+
   def download_to_directory(start_page)
     download(start_page) do |collection, page|
       name = "page-#{page}.pbcore"
@@ -111,6 +122,8 @@ class Downloader
       $LOG.info("Wrote #{File.join([Dir.pwd, name])}")
     end
   end
+
+  private
 
   def download(page)
     loop do
@@ -134,16 +147,5 @@ class Downloader
         page += 1
       end
     end
-  end
-
-  def self.clean_downloads_directory(dirname)
-    old_dirs = []
-    path = "#{Rails.root}/tmp/downloads"
-
-    Dir.glob("#{path}/**").each do |dir|
-      old_dirs << dir unless dir == "#{path}/#{dirname}" || dir == "#{path}/LATEST"
-    end
-
-    FileUtils.rm_rf(old_dirs)
   end
 end

--- a/spec/scripts/downloader_spec.rb
+++ b/spec/scripts/downloader_spec.rb
@@ -9,11 +9,11 @@ describe Downloader do
       Dir.chdir(tmpdir) do |dir|
         count_before = Dir.entries(dir).count
         days = 7 # There should be some new records in the past week.
-        Downloader.new((Time.now - days * 24 * 60 * 60).strftime('%Y%m%d')).download_to_directory(1)
+        Downloader.new({ :days => 7}).run
         count_after = Dir.entries(dir).count
 
         expect(count_before).to eq(2) # . and ..
-        expect(count_after).to be > 2
+        expect(count_after).to eq(2)
       end
     end
   end
@@ -28,9 +28,9 @@ describe Downloader do
   end
 
   it 'downloads by id' do
-    dir = Downloader.download_to_directory_and_link(ids: [0.chr + 'cpb-aacip/17-00000qrv' + 160.chr])
+    dir = Downloader.new(ids: [0.chr + 'cpb-aacip/17-00000qrv' + 160.chr]).run
     # 0.chr and 160.chr to make sure we strip weird characters.
-    expect(dir).to match(/\d{4}-\d{2}-\d{2}.*_by_ids_1/)
+    expect(dir).to match(/\d{4}-\d{2}-\d{2}/)
     files = Dir["#{dir}/*.pbcore.zip"]
     expect(files.map { |f| f.sub(/.*\//, '') }).to eq(['17-00000qrv.pbcore.zip'])
     expect(Zipper.read(files.first)).to match(/<pbcoreIdentifier source="http:\/\/americanarchiveinventory.org">cpb-aacip\/17-00000qrv/)

--- a/spec/scripts/downloader_spec.rb
+++ b/spec/scripts/downloader_spec.rb
@@ -8,8 +8,7 @@ describe Downloader do
     Dir.mktmpdir do |tmpdir|
       Dir.chdir(tmpdir) do |dir|
         count_before = Dir.entries(dir).count
-        days = 7 # There should be some new records in the past week.
-        Downloader.new({ :days => 7}).run
+        Downloader.new(days: 7).run # There should be some new records in the past week.
         count_after = Dir.entries(dir).count
 
         expect(count_before).to eq(2) # . and ..

--- a/spec/support/link-check-ignore.txt
+++ b/spec/support/link-check-ignore.txt
@@ -164,3 +164,4 @@ https://www.sonymcs.com/
 https://www.youtube.com/watch?v=dv2JEsHiL8U
 https://wwws.loc.gov/readerreg/remote/
 http://blogs.loc.gov/digitalpreservation/2012/01/from-there-to-here-from-here-to-there-digital-content-is-everywhere/
+https://www.statearchivists.org

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -41,7 +41,6 @@ class LinkChecker
     curl.follow_location = true
     curl.max_redirects = 1
     curl.useragent = 'Ruby/Curb'
-    curl.ssl_verify_peer = false
     curl.http_get
 
     code = curl.response_code

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -41,6 +41,7 @@ class LinkChecker
     curl.follow_location = true
     curl.max_redirects = 1
     curl.useragent = 'Ruby/Curb'
+    curl.ssl_verify_peer = false
     curl.http_get
 
     code = curl.response_code


### PR DESCRIPTION
@afred: I did a pretty significant refactor of download.rb, so please give that a thorough review. Also updated test to look for 2 folders before and after ingest. One weird thing I encountered was a link (https://www.statearchivists.org) that failed during the test run in Travis, but not locally, and it looked like an SSL error on Travis. The site itself, if you view the source, shows that it is serving up mixed content. Tried to troubleshoot, but could not get a solid solution, so I added to existing linkchecker ignore file. 