### PR TITLE
Upcases caption for capturing index for term in Caption

### DIFF
--- a/app/models/caption_file.rb
+++ b/app/models/caption_file.rb
@@ -30,8 +30,8 @@ class CaptionFile
     query.each do |term|
       return nil unless captions_dictionary.include?(term)
 
-      start = if (captions.index(term) - 200) > 0
-                captions.index(term) - 200
+      start = if (captions.upcase.index(term) - 200) > 0
+                captions.upcase.index(term) - 200
               else
                 0
               end


### PR DESCRIPTION
* Wouldn't find "Mary" for upcased "MARY"
* Closes #1146 

@afred - Not caught in tests with limited fixtures. Another thing to think about refactoring someday?