### PR TITLE
1088: Adds id to form input

### DIFF
--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -1,8 +1,8 @@
-<%= form_tag '/advanced', 
-  method: :post, 
+<%= form_tag '/advanced',
+  method: :post,
   class: 'search-query-form clearfix' do %>
 
-  <% { 
+  <% {
         all: 'All these words',
         title: 'This title',
         exact: 'This exact word or phrase',
@@ -11,7 +11,7 @@
       }.each do |name,label| %>
     <div class="form-group">
       <label for="<%= name %>"><%= label %></label>
-      <input class="form-control input-group input-group-lg" name="<%= name %>"/>
+      <input class="form-control input-group input-group-lg" name="<%= name %>" id="<%= name %>"/>
     </div>
   <% end %>
 


### PR DESCRIPTION
@afred: From NCAM's recommendation doc:

"On the Advanced Search page, form field names are labeled with the label element but lack matching id attributes on the inputs fields."

And from W3C:
"The for attribute of the label must exactly match the id of the form control."

* Closes #1088