### PR TITLE
1083: Hides thumbnails on search results page for screenreaders

### DIFF
--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -13,6 +13,7 @@
             <%= link_to(url_for_document(document))  do %>
               <img src="<%= pbcore.img_src %>"
                    class="media-object"
+                   aria-hidden="true"
                    alt="thumbnail of <%= pbcore.title %>" />
             <% end %>
 


### PR DESCRIPTION
@afred - Closes #1083. Issue was a request to hide the thumbnails from screenreaders on the search results page.