### PR TITLE
Moves imgs on Funding static page

### DIFF
--- a/app/views/override/about-the-american-archive/funding.md
+++ b/app/views/override/about-the-american-archive/funding.md
@@ -6,26 +6,18 @@ The American Archive of Public Broadcasting is generously supported by the follo
 
 ## Corporation for Public Broadcasting
 
-![CPB Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/cpb_logo.png)
-
-The Corporation for Public Broadcasting (CPB) promotes the growth and development of public media in communities throughout America. CPB provided funding for the American Archive Pilot Project, the American Archive Content Inventory Project, and the American Archive Digitization Project. Upon selecting WGBH and the Library of Congress as the permanent stewards of the American Archive of Public Broadcasting, CPB awarded these organizations a two-year grant to complete the digitization project, accession and ingest the AAPB collection into the Library's systems, develop a website for public access, and develop policies for sustaining the initiative and growing the collection.
+![CPB Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/cpb_logo.png) The Corporation for Public Broadcasting (CPB) promotes the growth and development of public media in communities throughout America. CPB provided funding for the American Archive Pilot Project, the American Archive Content Inventory Project, and the American Archive Digitization Project. Upon selecting WGBH and the Library of Congress as the permanent stewards of the American Archive of Public Broadcasting, CPB awarded these organizations a two-year grant to complete the digitization project, accession and ingest the AAPB collection into the Library's systems, develop a website for public access, and develop policies for sustaining the initiative and growing the collection.
 
 ## Council on Library and Information Resources
 
-![CLIR Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/clir_logo.png)
-
-The Council on Library and Information Resources (CLIR) awarded WGBH in collaboration with the Library of Congress a Cataloging Hidden Special Collections and Archives grant to lead the National Educational Television (NET) Collection Catalog Project, the first project to build upon the American Archive of Public Broadcasting initiative. This project will involve the creation of a national catalog of records to provide robust descriptions of programs distributed by NET (1952-1972), comprising the earliest public television content.
+![CLIR Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/clir_logo.png) The Council on Library and Information Resources (CLIR) awarded WGBH in collaboration with the Library of Congress a Cataloging Hidden Special Collections and Archives grant to lead the National Educational Television (NET) Collection Catalog Project, the first project to build upon the American Archive of Public Broadcasting initiative. This project will involve the creation of a national catalog of records to provide robust descriptions of programs distributed by NET (1952-1972), comprising the earliest public television content.
 
 ## Institute of Museum and Library Services
 
-![IMLS Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/imls_logo.png)
-
-The Institute of Museum and Library Services is the primary source of federal support for the nation’s 123,000 libraries and 35,000 museums. Our mission is to inspire libraries and museums to advance innovation, lifelong learning, and cultural and civic engagement. Our grant making, policy development, and research help libraries and museums deliver valuable services that make it possible for communities and individuals to thrive.
+![IMLS Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/imls_logo.png) The Institute of Museum and Library Services is the primary source of federal support for the nation’s 123,000 libraries and 35,000 museums. Our mission is to inspire libraries and museums to advance innovation, lifelong learning, and cultural and civic engagement. Our grant making, policy development, and research help libraries and museums deliver valuable services that make it possible for communities and individuals to thrive.
 
 The Laura Bush 21st Century Librarian Program supports projects to recruit and educate the next generation of librarians, faculty, and library leaders; and to support early career research. It also assists in the professional development of librarians and library staff.
 
 ## National Endowment for the Humanities
 
-![NEH Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/neh_logo.jpg)
-
-Created in 1965 as an independent federal agency, the National Endowment for the Humanities supports research and learning in history, literature, philosophy, and other areas of the humanities by funding selected, peer-reviewed proposals from around the nation. Additional information about the National Endowment for the Humanities and its grant programs is available at: www.neh.gov.
+![NEH Logo Image](https://s3.amazonaws.com/americanarchive.org/org-logos/neh_logo.jpg) Created in 1965 as an independent federal agency, the National Endowment for the Humanities supports research and learning in history, literature, philosophy, and other areas of the humanities by funding selected, peer-reviewed proposals from around the nation. Additional information about the National Endowment for the Humanities and its grant programs is available at: www.neh.gov.


### PR DESCRIPTION
This is done by removing newlines between images and the beginning of
paragraphs. The result is that the image itself is not wrapped in it's
own <p> element, but is containing the the same <p> element as the text,
where existing CSS padding rules apply more cleanly.

Closes #1190.