### PR TITLE
Adjust check for affirmed TOS

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User
   end
 
   def affirmed_tos?
-    request.session[:affirm_terms]
+    request.cookies['orr_rules_of_use'] == 'y'
   end
 
   private

--- a/app/views/catalog/_rules_of_use_modal.html.erb
+++ b/app/views/catalog/_rules_of_use_modal.html.erb
@@ -13,9 +13,7 @@
             <iframe src="/plain_override/rules-of-use" style="width: 100%;"></iframe>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="
-              document.cookie = '<%= cookie_name %>=y;max-age=<%= 60*60 %>'"
-            >I Agree</button>
+            <button type="button" class="btn btn-primary" data-dismiss="modal" onclick="document.cookie = '<%= cookie_name %>=y;max-age=<%= 60*60 %>'">I Agree</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
* Needs to check cookie instead of session
* Also removes unnecessary newlines from the "rules of use" modal.

Fixes #1249