### PR TITLE
1267: Marks player css with data-turbolinks-track

### DIFF
--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:head) do %>
-  <link href="http://vjs.zencdn.net/5.11.7/video-js.css" rel="stylesheet">
+  <link href="http://vjs.zencdn.net/5.11.7/video-js.css" rel="stylesheet" data-turbolinks-track>
   <script src="http://vjs.zencdn.net/5.11.7/video.js"></script>
   <!-- video-js support for IE 8 -->
   <script src="http://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script>


### PR DESCRIPTION
@afred - this will make sure we're using latest css inside turbolinks session. solved the issue for me locally.