### PR TITLE
Upgrades to ruby 2.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.2.2
+- 2.2.4
 sudo: false
 cache: bundler
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@
 source 'https://rubygems.org'
 
 # Specify specific version of ruby with which the app is compatible.
-ruby '2.2.2'
+ruby '2.2.4'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.19)
     logger (1.2.8)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -182,9 +182,9 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (10.4.2)
-    rdoc (4.2.0)
+    rdoc (4.3.0)
     redcarpet (3.3.4)
-    ref (1.0.5)
+    ref (2.0.0)
     rsolr (1.0.12)
       builder (>= 2.1.2)
     rspec (3.2.0)
@@ -251,8 +251,8 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     stomp (1.3.4)
-    therubyracer (0.12.1)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -329,7 +329,7 @@ DEPENDENCIES
   wordpress-client
 
 RUBY VERSION
-   ruby 2.2.2p95
+   ruby 2.2.4p230
 
 BUNDLED WITH
-   1.13.6
+   1.15.1


### PR DESCRIPTION
The latest Ruby version is actually 2.4.1, but jumping that far will require
some dependency resolution, which I found by trying to go just to Ruby 2.3.x.
The reason we're going to 2.2.4 now is because we're changing how we install
ruby on production machines. Instead of installing from source, or using RVM,
we're simply installing the yum package 'ruby22', which brings in the latest
point release, in this case 2.2.4.

This is easier (and faster)from a provisioning standpoint, which is why we're
doing it. But it means that the yum package may move forward with a point
release, and get out of sync with the ruby version specified in the Gemfile.
The result would be that running 'bundle install' will fail, which is something
we should catch when deploying to demo instances (prior to deploying to
production). The fix is to bump the ruby versions in the Gemfile again, just
like this commit does.