### PR TITLE
20170626 release fixes

### DIFF
--- a/app/assets/stylesheets/globals/header.css.scss
+++ b/app/assets/stylesheets/globals/header.css.scss
@@ -22,6 +22,7 @@
  */
 #main-container {
 	padding: 0 0 3em 0;
+  overflow-x: hidden;
 }
 
 #donate {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,3 +6,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+
+Rails.application.config.assets.precompile += %w( player.js )


### PR DESCRIPTION
@afred - @sroosa had me release the latest code to demo (54.211.129.30). In manual testing I found a couple things that need tweaks. First, somehow the sticky nav on the homepage was overflowing on the x axis. Second, the new player.js file wasn't available for transcripts after release. I think precompiling it from assets.rb initializer should fix the issue. 

Could you take a quick look and merge? Thanks!