### PR TITLE
Forgot to use javascript-include_tag for player.js

### DIFF
--- a/app/assets/javascripts/player.js
+++ b/app/assets/javascripts/player.js
@@ -9,7 +9,7 @@ $(function(){
 
   var $transcript = $('#transcript');
 
-  $(document).ready(function() {
+  $(window).load(function() {
     var lines = {};
     $transcript.contents().find('[data-timecodebegin]').each(function(i,el){
         var $el = $(el);

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -4,7 +4,7 @@
   <!-- video-js support for IE 8 -->
   <script src="http://vjs.zencdn.net/ie8/1.1.2/videojs-ie8.min.js"></script>
   <!-- Need VideoJS for our player.js file -->
-  <script src="/assets/player.js"></script>
+  <%= javascript_include_tag 'player' %>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
@afred - 2 more things I had to update.
* Need to use javascript_include_tag instead of relative path for JS stub
* Also updates player.js to run on window.load since player wasn't ready on document.ready after update above.