### PR TITLE
Station logos

### DIFF
--- a/app/views/organizations/md/1254.md
+++ b/app/views/organizations/md/1254.md
@@ -14,7 +14,7 @@ Anchorage
 
 ## Logo
 
-koahnic_logo.png
+koahnic\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1271.md
+++ b/app/views/organizations/md/1271.md
@@ -14,7 +14,7 @@ Sitka
 
 ## Logo
 
-kcaw_logo.png
+kcaw\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1275.md
+++ b/app/views/organizations/md/1275.md
@@ -14,7 +14,7 @@ Unalaska
 
 ## Logo
 
-kucb_logo.png
+kucb\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1347.md
+++ b/app/views/organizations/md/1347.md
@@ -14,7 +14,7 @@ Jacksonville
 
 ## Logo
 
-wjct_logo.png
+wjct\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1388.md
+++ b/app/views/organizations/md/1388.md
@@ -14,7 +14,7 @@ Indianapolis
 
 ## Logo
 
-wfyi_logo.png
+wfyi\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1393.md
+++ b/app/views/organizations/md/1393.md
@@ -14,7 +14,7 @@ Des Moines
 
 ## Logo
 
-iowa_pr_logo.png
+iowa\_pr\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1430.md
+++ b/app/views/organizations/md/1430.md
@@ -14,7 +14,7 @@ East Orland
 
 ## Logo
 
-weru_logo.png
+weru\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1438.md
+++ b/app/views/organizations/md/1438.md
@@ -14,7 +14,7 @@ Amherst
 
 ## Logo
 
-nepr_logo.png
+nepr\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1441.md
+++ b/app/views/organizations/md/1441.md
@@ -14,7 +14,7 @@ Boston
 
 ## Logo
 
-wumb_logo.png
+wumb\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1466.md
+++ b/app/views/organizations/md/1466.md
@@ -14,7 +14,7 @@ St. Paul
 
 ## Logo
 
-mpr_logo.png
+mpr\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1527.md
+++ b/app/views/organizations/md/1527.md
@@ -14,7 +14,7 @@ New York
 
 ## Logo
 
-wnyc_logo.png
+wnyc\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1531.md
+++ b/app/views/organizations/md/1531.md
@@ -14,7 +14,7 @@ Rochester
 
 ## Logo
 
-wxxi_logo.png
+wxxi\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1570.md
+++ b/app/views/organizations/md/1570.md
@@ -14,7 +14,7 @@ Yellow Springs
 
 ## Logo
 
-wyso_logo.png
+wyso\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1571.md
+++ b/app/views/organizations/md/1571.md
@@ -14,7 +14,7 @@ Youngstown
 
 ## Logo
 
-wysu_logo.png
+wysu\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1616.md
+++ b/app/views/organizations/md/1616.md
@@ -14,7 +14,7 @@ Austin
 
 ## Logo
 
-kut_logo.png
+kut\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1642.md
+++ b/app/views/organizations/md/1642.md
@@ -14,7 +14,7 @@ Colchester
 
 ## Logo
 
-vpr_logo.png
+vpr\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1658.2.md
+++ b/app/views/organizations/md/1658.2.md
@@ -14,7 +14,7 @@ Seattle
 
 ## Logo
 
-kexp_logo.png
+kexp\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1709.md
+++ b/app/views/organizations/md/1709.md
@@ -14,7 +14,7 @@ Rohnert Park
 
 ## Logo
 
-krcb_logo.png
+krcb\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1710.md
+++ b/app/views/organizations/md/1710.md
@@ -14,7 +14,7 @@ Costa Mesa
 
 ## Logo
 
-pbs_socal_logo.png
+pbs\_socal\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1716.md
+++ b/app/views/organizations/md/1716.md
@@ -14,7 +14,7 @@ Sacramento
 
 ## Logo
 
-kvie_logo.png
+kvie\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1720.md
+++ b/app/views/organizations/md/1720.md
@@ -14,7 +14,7 @@ San Francisco
 
 ## Logo
 
-kqed_logo.png
+kqed\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1723.md
+++ b/app/views/organizations/md/1723.md
@@ -14,7 +14,7 @@ Denver
 
 ## Logo
 
-colorado_pt_logo.png
+colorado\_pt\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1724.md
+++ b/app/views/organizations/md/1724.md
@@ -14,7 +14,7 @@ Denver
 
 ## Logo
 
-rocky_mountain_logo.png
+rocky\_mountain\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1727.md
+++ b/app/views/organizations/md/1727.md
@@ -14,7 +14,7 @@ Hartford
 
 ## Logo
 
-cpbn_logo.png
+cpbn\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1731.md
+++ b/app/views/organizations/md/1731.md
@@ -14,7 +14,7 @@ Washington
 
 ## Logo
 
-whut_logo.png
+whut\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1742.md
+++ b/app/views/organizations/md/1742.md
@@ -14,7 +14,7 @@ Tampa
 
 ## Logo
 
-wedu_logo.png
+wedu\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1748.md
+++ b/app/views/organizations/md/1748.md
@@ -14,7 +14,7 @@ Honolulu
 
 ## Logo
 
-pbs_hawaii_logo.png
+pbs\_hawaii\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1760.md
+++ b/app/views/organizations/md/1760.md
@@ -14,7 +14,7 @@ Urbana
 
 ## Logo
 
-will_logo.png
+will\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1761.md
+++ b/app/views/organizations/md/1761.md
@@ -14,7 +14,7 @@ Bloomington
 
 ## Logo
 
-wtiu_logo.png
+wtiu\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1777.md
+++ b/app/views/organizations/md/1777.md
@@ -14,7 +14,7 @@ Baton Rouge
 
 ## Logo
 
-lpb_logo.png
+lpb\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1781.md
+++ b/app/views/organizations/md/1781.md
@@ -14,7 +14,7 @@ Lewiston
 
 ## Logo
 
-mpbn_logo.png
+mpbn\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1783.md
+++ b/app/views/organizations/md/1783.md
@@ -14,7 +14,7 @@ Owings Mills
 
 ## Logo
 
-mpt_logo.png
+mpt\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1784.2.md
+++ b/app/views/organizations/md/1784.2.md
@@ -14,7 +14,7 @@ Boston
 
 ## Logo
 
-wgbh_logo.png
+wgbh\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1784.md
+++ b/app/views/organizations/md/1784.md
@@ -14,7 +14,7 @@ Springfield
 
 ## Logo
 
-wgby_logo.png
+wgby\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1787.md
+++ b/app/views/organizations/md/1787.md
@@ -14,7 +14,7 @@ East Lansing
 
 ## Logo
 
-wkar_logo.png
+wkar\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1789.md
+++ b/app/views/organizations/md/1789.md
@@ -14,7 +14,7 @@ Grand Rapids
 
 ## Logo
 
-wgvu_logo.png
+wgvu\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1793.md
+++ b/app/views/organizations/md/1793.md
@@ -14,7 +14,7 @@ Appleton
 
 ## Logo
 
-pioneer_logo.png
+pioneer\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1797.md
+++ b/app/views/organizations/md/1797.md
@@ -14,7 +14,7 @@ St. Paul
 
 ## Logo
 
-tpt_logo.png
+tpt\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1799.md
+++ b/app/views/organizations/md/1799.md
@@ -14,7 +14,7 @@ Kansas City
 
 ## Logo
 
-kcpt_logo.png
+kcpt\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1801.md
+++ b/app/views/organizations/md/1801.md
@@ -14,7 +14,7 @@ Springfield
 
 ## Logo
 
-ozarks_logo.png
+ozarks\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1809.md
+++ b/app/views/organizations/md/1809.md
@@ -14,7 +14,7 @@ Trenton
 
 ## Logo
 
-njn_logo.png
+njn\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1810.md
+++ b/app/views/organizations/md/1810.md
@@ -14,7 +14,7 @@ Albuquerque
 
 ## Logo
 
-newmexicopbs_logo.png
+newmexicopbs\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1817.md
+++ b/app/views/organizations/md/1817.md
@@ -14,7 +14,7 @@ New York
 
 ## Logo
 
-wnet_logo.png
+wnet\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1820.md
+++ b/app/views/organizations/md/1820.md
@@ -14,7 +14,7 @@ Troy
 
 ## Logo
 
-wmht_logo.png
+wmht\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1822.md
+++ b/app/views/organizations/md/1822.md
@@ -14,7 +14,7 @@ Liverpool
 
 ## Logo
 
-wcny_logo.png
+wcny\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1824.md
+++ b/app/views/organizations/md/1824.md
@@ -14,7 +14,7 @@ Research Triangle Park
 
 ## Logo
 
-unctv_logo.png
+unctv\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1826.md
+++ b/app/views/organizations/md/1826.md
@@ -14,7 +14,7 @@ Fargo
 
 ## Logo
 
-prairie_logo.png
+prairie\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1832.md
+++ b/app/views/organizations/md/1832.md
@@ -14,7 +14,7 @@ Columbus
 
 ## Logo
 
-wosu_logo.png
+wosu\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1839.md
+++ b/app/views/organizations/md/1839.md
@@ -14,7 +14,7 @@ Medford
 
 ## Logo
 
-soptv_logo.png
+soptv\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1844.md
+++ b/app/views/organizations/md/1844.md
@@ -14,7 +14,7 @@ Philadelphia
 
 ## Logo
 
-whyy_logo.png
+whyy\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1846.md
+++ b/app/views/organizations/md/1846.md
@@ -14,7 +14,7 @@ Pittsburgh
 
 ## Logo
 
-wqed_logo.png
+wqed\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1848.md
+++ b/app/views/organizations/md/1848.md
@@ -14,7 +14,7 @@ Pittston
 
 ## Logo
 
-wvia_logo.png
+wvia\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1851.md
+++ b/app/views/organizations/md/1851.md
@@ -14,7 +14,7 @@ Columbia
 
 ## Logo
 
-scetv_logo.png
+scetv\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1881.md
+++ b/app/views/organizations/md/1881.md
@@ -14,7 +14,7 @@ Salt Lake City
 
 ## Logo
 
-kued_logo.png
+kued\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1882.md
+++ b/app/views/organizations/md/1882.md
@@ -14,7 +14,7 @@ Colchester
 
 ## Logo
 
-vermont_pt.png
+vermont\_pt.png
 
 ## Url
 

--- a/app/views/organizations/md/1888.md
+++ b/app/views/organizations/md/1888.md
@@ -14,7 +14,7 @@ Roanoke
 
 ## Logo
 
-wbra_logo.png
+wbra\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1896.2.md
+++ b/app/views/organizations/md/1896.2.md
@@ -14,7 +14,7 @@ Madison
 
 ## Logo
 
-wpr_logo.png
+wpr\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1896.md
+++ b/app/views/organizations/md/1896.md
@@ -14,7 +14,7 @@ Madison
 
 ## Logo
 
-wpt_logo.png
+wpt\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1898.md
+++ b/app/views/organizations/md/1898.md
@@ -14,7 +14,7 @@ Riverton
 
 ## Logo
 
-wyoming_pbs_logo.png
+wyoming\_pbs\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/1900.md
+++ b/app/views/organizations/md/1900.md
@@ -14,7 +14,7 @@ Mangilao
 
 ## Logo
 
-pbs_guam_logo.png
+pbs\_guam\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/4502.md
+++ b/app/views/organizations/md/4502.md
@@ -14,7 +14,7 @@ Warm Springs
 
 ## Logo
 
-kwso_logo.png
+kwso\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/4608.md
+++ b/app/views/organizations/md/4608.md
@@ -14,7 +14,7 @@ Bozeman
 
 ## Logo
 
-kglt_logo.png
+kglt\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/4721.md
+++ b/app/views/organizations/md/4721.md
@@ -14,7 +14,7 @@ Knoxville
 
 ## Logo
 
-wdvx_logo.png
+wdvx\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/4857.md
+++ b/app/views/organizations/md/4857.md
@@ -14,7 +14,7 @@ Jersey City
 
 ## Logo
 
-wfmu_logo.png
+wfmu\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/NCSG0150.md
+++ b/app/views/organizations/md/NCSG0150.md
@@ -14,7 +14,7 @@ College Park
 
 ## Logo
 
-umd_logo.png
+umd\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/NCSG43.md
+++ b/app/views/organizations/md/NCSG43.md
@@ -14,7 +14,7 @@ North Hollywood
 
 ## Logo
 
-pacifica_logo.png
+pacifica\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/NCSG55084.md
+++ b/app/views/organizations/md/NCSG55084.md
@@ -14,7 +14,7 @@ Lincoln
 
 ## Logo
 
-vision_maker_media_logo.png
+vision\_maker\_media\_logo.png
 
 ## Url
 

--- a/app/views/organizations/md/NewsHourProductions.md
+++ b/app/views/organizations/md/NewsHourProductions.md
@@ -14,7 +14,7 @@ Washington
 
 ## Logo
 
-newshour_logo.png
+newshour\_logo.png
 
 ## Url
 


### PR DESCRIPTION
escapes the underscores in the logo filenames, so they are called from s3 correctly as per #1264 