### PR TITLE
Newsmag exhibit final tweaks

### DIFF
--- a/app/views/exhibits/newsmagazines/definitive-newsmags.md
+++ b/app/views/exhibits/newsmagazines/definitive-newsmags.md
@@ -85,3 +85,5 @@ The newsmagazines in the AAPB embody these principles and challenge the critique
 - 2016—Louisiana: The State We're In: [2015 Year in Review](/catalog/cpb-aacip_509-f18sb3xn1x)
 
 ## Main
+
+## Resources

--- a/app/views/exhibits/newsmagazines/precedents.md
+++ b/app/views/exhibits/newsmagazines/precedents.md
@@ -50,3 +50,5 @@ If there’s one thread that weaves these narrative strands together, it’s PBS
 #### Next: [Quintessential Newsmagazines](/exhibits/newsmagazines/definitive-newsmags)
 
 ## Main
+
+## Resources


### PR DESCRIPTION
should fix the main section from exhibit page appearing at the end of each sub-section page. 