### PR TITLE
1116 Chapter Files

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -37,3 +37,4 @@
 @import "locals/kimbia";
 @import "locals/transcript";
 @import "locals/kludge";
+@import "locals/player";

--- a/app/assets/stylesheets/locals/player.css.scss
+++ b/app/assets/stylesheets/locals/player.css.scss
@@ -1,0 +1,18 @@
+/* -------------------- */
+/* Player ------------- */
+/* -------------------- */
+
+.vjs-chapters-button {
+  .vjs-menu {
+    .vjs-menu-content {
+      width: 175px !important;
+      margin-left: -70px;
+      .vjs-menu-item {
+        text-transform: none;
+      }
+    }
+    li.vjs-menu-title {
+        font-size: 1.2em;
+    }
+  }
+}

--- a/app/models/chapter_file.rb
+++ b/app/models/chapter_file.rb
@@ -1,0 +1,18 @@
+require 'open-uri'
+
+class ChapterFile
+  URL_BASE = 'https://s3.amazonaws.com/americanarchive.org/chapters'.freeze
+
+  def self.vtt_filename(id)
+    "#{id}.vtt".gsub('cpb-aacip_', 'cpb-aacip-')
+  end
+
+  def self.vtt_url(id)
+    "#{ChapterFile::URL_BASE}/#{id}/#{vtt_filename(id)}".gsub('cpb-aacip_', 'cpb-aacip-')
+  end
+
+  def self.file_present?(id)
+    return true if Net::HTTP.get_response(URI.parse(ChapterFile.vtt_url(id))).code == '200'
+    false
+  end
+end

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -29,6 +29,9 @@
           <% if @pbcore.captions_src %>
             <track kind="captions" src="/captions/<%= @pbcore.id %>.vtt" srclang="en" label="English" default="default" />
           <% end %>
+          <% if ChapterFile.file_present?(@pbcore.id) %>
+            <track kind="chapters" src=<%= ChapterFile.vtt_url(@pbcore.id) %> srclang="en" label="Chapters" />
+          <% end %>
           <%
         end
       end.join().html_safe()

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -29,7 +29,7 @@ describe 'API' do
       expect(page).to have_text('my_callback({ "responseHeader"')
       expect(page).to have_text('"rows": "0"')
       expect(page).to have_text('"year:1988 AND iowa": 1')
-      expect(page).to have_text('"numFound": 30')
+      expect(page).to have_text('"numFound": 31')
       expect(page).to have_text('"1981", 1, "1983", 1, "1988", 1, "1990", 1, "1992", 1, "2000", 1')
     end
 

--- a/spec/fixtures/chapters/cpb-aacip-114-90dv49m9.vtt
+++ b/spec/fixtures/chapters/cpb-aacip-114-90dv49m9.vtt
@@ -1,0 +1,25 @@
+WEBVTT
+
+Chapter 1
+00:00:00.000 --> 00:01:41.000
+Opening
+
+Chapter 2
+00:01:41.000 --> 00:08:06.000
+Rose-Ann's Bakery
+
+Chapter 3
+00:08:06.000 --> 00:16:06.000
+Bart's Ice Cream, Part 1
+
+Chapter 4
+00:16:06.000 --> 00:21:58.000
+Chocolate Works
+
+Chapter 5
+00:21:58.000 --> 00:24:17.000
+Bart's Ice Cream, Part 2
+
+Chapter 6
+00:24:17.000 --> 00:25:46.000
+Credits

--- a/spec/fixtures/pbcore/clean-has-chapters.xml
+++ b/spec/fixtures/pbcore/clean-has-chapters.xml
@@ -1,0 +1,231 @@
+<pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd">
+<pbcoreAssetType>Episode</pbcoreAssetType>
+<pbcoreAssetDate dateType="Date">2003-01-22</pbcoreAssetDate>
+<pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/114-90dv49m9</pbcoreIdentifier>
+<pbcoreIdentifier source="Sony Ci">b3f3f1543ce84ec2b2644bdd4b99e5b8</pbcoreIdentifier>
+<pbcoreTitle titleType="Series">Making It Here</pbcoreTitle>
+<pbcoreTitle titleType="Episode Number">105</pbcoreTitle>
+<pbcoreTitle titleType="Episode">Sweets</pbcoreTitle>
+<pbcoreDescription descriptionType="Episode">
+This episode visits two businesses in Greenfield, MA, Rose-Ann's Bakery and Catering and Bart's Ice Cream, as well as a business in East Longmeadow, MA, called Chocolate Works.
+</pbcoreDescription>
+<pbcoreDescription descriptionType="Description">
+Making It Here is a magazine featuring segments that highlight local workers and the work that they do.
+</pbcoreDescription>
+<pbcoreGenre source="AAPB Format Genre" annotation="genre">Magazine</pbcoreGenre>
+<pbcoreGenre source="AAPB Topical Genre" annotation="topic">Business</pbcoreGenre>
+<pbcoreGenre source="AAPB Topical Genre" annotation="topic">Local Communities</pbcoreGenre>
+<pbcoreGenre source="AAPB Topical Genre" annotation="topic">Food and Cooking</pbcoreGenre>
+<pbcoreCreator>
+<creator>Fraser, David</creator>
+<creatorRole>Producer</creatorRole>
+</pbcoreCreator>
+<pbcoreCreator>
+<creator>Lash, James</creator>
+<creatorRole>Executive Producer</creatorRole>
+</pbcoreCreator>
+<pbcoreCreator>
+<creator>Zippay, Marla</creator>
+<creatorRole>Producer</creatorRole>
+</pbcoreCreator>
+<pbcoreCreator>
+<creator>Murphy, Meagan</creator>
+<creatorRole>Producer</creatorRole>
+</pbcoreCreator>
+<pbcoreContributor>
+<contributor>Murphy, George</contributor>
+<contributorRole>Host</contributorRole>
+</pbcoreContributor>
+<pbcoreContributor>
+<contributor>Laferriere, Raymond</contributor>
+<contributorRole>Editor</contributorRole>
+</pbcoreContributor>
+<pbcoreContributor>
+<contributor>Murphy, Heather</contributor>
+<contributorRole>Editor</contributorRole>
+</pbcoreContributor>
+<pbcoreContributor>
+<contributor>Harder, Rose-Ann</contributor>
+<contributorRole>Guest</contributorRole>
+</pbcoreContributor>
+<pbcoreContributor>
+<contributor>Schaefer, Gary</contributor>
+<contributorRole>Guest</contributorRole>
+</pbcoreContributor>
+<pbcoreContributor>
+<contributor>Sherman, Walter</contributor>
+<contributorRole>Guest</contributorRole>
+</pbcoreContributor>
+<pbcorePublisher>
+<publisher>WGBY</publisher>
+<publisherRole>Copyright Holder</publisherRole>
+</pbcorePublisher>
+<pbcoreRightsSummary>
+<rightsSummary>
+A production of WGBY a division of the WGBH Educational Foundation Copyright 2003.
+</rightsSummary>
+</pbcoreRightsSummary>
+<pbcoreInstantiation>
+<instantiationIdentifier source="WGBY Library &amp; Archives">AL110515</instantiationIdentifier>
+<instantiationDate dateType="issued">2013-06-17</instantiationDate>
+<instantiationPhysical>Betacam SP</instantiationPhysical>
+<instantiationLocation>R5 B1 S5</instantiationLocation>
+<instantiationMediaType>Moving Image</instantiationMediaType>
+<instantiationGenerations>Master</instantiationGenerations>
+<instantiationDuration>00:25:20</instantiationDuration>
+<instantiationChannelConfiguration>Ch 1 Full Mix; Ch 2 Full Mix</instantiationChannelConfiguration>
+<instantiationAlternativeModes>N</instantiationAlternativeModes>
+<instantiationExtension>
+<extensionWrap>
+<extensionElement>AACIP Record Nomination Status</extensionElement>
+<extensionValue>Nominated/1st Priority</extensionValue>
+<extensionAuthorityUsed>AACIP</extensionAuthorityUsed>
+</extensionWrap>
+</instantiationExtension>
+</pbcoreInstantiation>
+<pbcoreInstantiation>
+<instantiationIdentifier source="mediainfo">cpb-aacip-114-90dv49m9.mpeg2.mxf</instantiationIdentifier>
+<instantiationDate dateType="encoded">2014-03-05</instantiationDate>
+<instantiationDigital>application/mxf</instantiationDigital>
+<instantiationStandard>OP-1a</instantiationStandard>
+<instantiationLocation>N/A</instantiationLocation>
+<instantiationMediaType>Moving Image</instantiationMediaType>
+<instantiationGenerations>Mezzanine</instantiationGenerations>
+<instantiationFileSize unitsOfMeasure="GiB">11</instantiationFileSize>
+<instantiationDataRate unitsOfMeasure="Mbps">63</instantiationDataRate>
+<instantiationTracks>1 video, 1 audio</instantiationTracks>
+<instantiationChannelConfiguration>4 channel</instantiationChannelConfiguration>
+<instantiationEssenceTrack>
+<essenceTrackType>video</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">2</essenceTrackIdentifier>
+<essenceTrackStandard>NTSC</essenceTrackStandard>
+<essenceTrackEncoding source="mediainfo">MPEG-2 Video</essenceTrackEncoding>
+<essenceTrackDataRate unitsOfMeasure="Mbps">50</essenceTrackDataRate>
+<essenceTrackFrameRate>29.970</essenceTrackFrameRate>
+<essenceTrackBitDepth>8</essenceTrackBitDepth>
+<essenceTrackFrameSize>720 x 486</essenceTrackFrameSize>
+<essenceTrackAspectRatio>4:3</essenceTrackAspectRatio>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+<essenceTrackAnnotation annotationType="colorspace">YUV</essenceTrackAnnotation>
+<essenceTrackAnnotation annotationType="subsampling">4:2:2</essenceTrackAnnotation>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>audio</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">3</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">PCM</essenceTrackEncoding>
+<essenceTrackDataRate unitsOfMeasure="Mbps">12</essenceTrackDataRate>
+<essenceTrackSamplingRate>48.0 KHz</essenceTrackSamplingRate>
+<essenceTrackBitDepth>16</essenceTrackBitDepth>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>other</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">1</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">MXF TC</essenceTrackEncoding>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>other</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">1</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">SMPTE TC</essenceTrackEncoding>
+</instantiationEssenceTrack>
+<instantiationAnnotation annotationType="encoded by">OC OCTk 2.1</instantiationAnnotation>
+</pbcoreInstantiation>
+<pbcoreInstantiation>
+<instantiationIdentifier source="mediainfo">cpb-aacip-114-90dv49m9.j2k.mxf</instantiationIdentifier>
+<instantiationDate dateType="encoded">2014-03-05</instantiationDate>
+<instantiationDigital>application/mxf</instantiationDigital>
+<instantiationStandard>OP-1a</instantiationStandard>
+<instantiationLocation>N/A</instantiationLocation>
+<instantiationMediaType>Moving Image</instantiationMediaType>
+<instantiationGenerations>Preservation Master</instantiationGenerations>
+<instantiationFileSize unitsOfMeasure="GiB">14</instantiationFileSize>
+<instantiationDataRate unitsOfMeasure="Mbps">75</instantiationDataRate>
+<instantiationTracks>1 video, 1 audio</instantiationTracks>
+<instantiationChannelConfiguration>4 channel</instantiationChannelConfiguration>
+<instantiationEssenceTrack>
+<essenceTrackType>video</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">1</essenceTrackIdentifier>
+<essenceTrackStandard>NTSC</essenceTrackStandard>
+<essenceTrackEncoding source="mediainfo" ref="http://www.morgan-multimedia.com/JPEG 2000/">JPEG 2000</essenceTrackEncoding>
+<essenceTrackDataRate unitsOfMeasure="Mbps">72</essenceTrackDataRate>
+<essenceTrackFrameRate>59.940</essenceTrackFrameRate>
+<essenceTrackBitDepth>8</essenceTrackBitDepth>
+<essenceTrackFrameSize>720 x 486</essenceTrackFrameSize>
+<essenceTrackAspectRatio>4:3</essenceTrackAspectRatio>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+<essenceTrackAnnotation annotationType="colorspace">YUV</essenceTrackAnnotation>
+<essenceTrackAnnotation annotationType="subsampling">4:2:2</essenceTrackAnnotation>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>audio</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">2</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">PCM</essenceTrackEncoding>
+<essenceTrackDataRate unitsOfMeasure="Kbps">3072</essenceTrackDataRate>
+<essenceTrackSamplingRate>48.0 KHz</essenceTrackSamplingRate>
+<essenceTrackBitDepth>16</essenceTrackBitDepth>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>other</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">0</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">SMPTE TC</essenceTrackEncoding>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>other</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">1</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">SMPTE TC</essenceTrackEncoding>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+</instantiationEssenceTrack>
+<instantiationAnnotation annotationType="encoded by">
+Front Porch Digital J2K MXF Wrapper Based on MXFLib 1.0.1(13)-Beta
+</instantiationAnnotation>
+</pbcoreInstantiation>
+<pbcoreInstantiation>
+<instantiationIdentifier source="mediainfo">cpb-aacip-114-90dv49m9.h264.mov</instantiationIdentifier>
+<instantiationDate dateType="encoded">2014-03-05</instantiationDate>
+<instantiationDigital>video/mp4</instantiationDigital>
+<instantiationStandard>QuickTime</instantiationStandard>
+<instantiationLocation>N/A</instantiationLocation>
+<instantiationMediaType>Moving Image</instantiationMediaType>
+<instantiationGenerations>Proxy</instantiationGenerations>
+<instantiationFileSize unitsOfMeasure="MiB">158</instantiationFileSize>
+<instantiationDataRate unitsOfMeasure="Kbps">857</instantiationDataRate>
+<instantiationTracks>1 video, 1 audio</instantiationTracks>
+<instantiationChannelConfiguration>2 channel</instantiationChannelConfiguration>
+<instantiationEssenceTrack>
+<essenceTrackType>video</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">1</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo" ref="http://developers.videolan.org/x264.html">AVC</essenceTrackEncoding>
+<essenceTrackDataRate unitsOfMeasure="Kbps">722</essenceTrackDataRate>
+<essenceTrackFrameRate>29.970</essenceTrackFrameRate>
+<essenceTrackBitDepth>8</essenceTrackBitDepth>
+<essenceTrackFrameSize>480 x 360</essenceTrackFrameSize>
+<essenceTrackAspectRatio>4:3</essenceTrackAspectRatio>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+<essenceTrackLanguage>eng</essenceTrackLanguage>
+<essenceTrackAnnotation annotationType="colorspace">YUV</essenceTrackAnnotation>
+<essenceTrackAnnotation annotationType="subsampling">4:2:0</essenceTrackAnnotation>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>audio</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">2</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">AAC LC</essenceTrackEncoding>
+<essenceTrackDataRate unitsOfMeasure="Kbps">128</essenceTrackDataRate>
+<essenceTrackSamplingRate>48.0 KHz</essenceTrackSamplingRate>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+<essenceTrackLanguage>eng</essenceTrackLanguage>
+</instantiationEssenceTrack>
+<instantiationEssenceTrack>
+<essenceTrackType>other</essenceTrackType>
+<essenceTrackIdentifier source="mediainfo">3</essenceTrackIdentifier>
+<essenceTrackEncoding source="mediainfo">QuickTime TC</essenceTrackEncoding>
+<essenceTrackDuration>00:25:45</essenceTrackDuration>
+<essenceTrackLanguage>eng</essenceTrackLanguage>
+</instantiationEssenceTrack>
+<instantiationAnnotation annotationType="encoded by">Apple QuickTime</instantiationAnnotation>
+</pbcoreInstantiation>
+<pbcoreAnnotation annotationType="Level of User Access">Online Reading Room</pbcoreAnnotation>
+<pbcoreAnnotation annotationType="cataloging status">Minimally Cataloged</pbcoreAnnotation>
+<pbcoreAnnotation annotationType="last_modified">2015-08-27 11:16:26</pbcoreAnnotation>
+<pbcoreAnnotation annotationType="organization">WGBY</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/models/chapter_file_spec.rb
+++ b/spec/models/chapter_file_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require 'webmock'
+
+describe ChapterFile do
+  before :all do
+    # WebMock is disabled by defafult, but we use it for these tests.
+    # Note that it is re-disable in an :after hook below.
+    WebMock.enable!
+  end
+
+  let(:id_1) { 'cpb-aacip_114-90dv49m9' }
+  let(:id_2) { 'fake_id' }
+  let(:vtt_example_1) { File.read('./spec/fixtures/chapters/cpb-aacip-114-90dv49m9.vtt') }
+
+  before do
+    # Stub requests so we don't actually have to fetch them remotely. But note
+    # that this requires that the files have been pulled down and saved in
+    # ./spec/fixtures/srt/ with the same filename they have in S3.
+    WebMock.stub_request(:get, ChapterFile.vtt_url(id_1)).to_return(body: vtt_example_1)
+    WebMock.stub_request(:get, ChapterFile.vtt_url(id_2)).to_return(status: 400, body: '', headers: {})
+  end
+
+  ###
+  # Class method tests
+  ###
+
+  describe '.vtt_filename' do
+    it 'returns the filename based on the ID' do
+      expect(ChapterFile.vtt_filename(id_1)).to eq('cpb-aacip-114-90dv49m9.vtt')
+    end
+  end
+
+  describe '.vtt_url' do
+    it 'returns the URL to the remote SRT caption file' do
+      expect(ChapterFile.vtt_url(id_1)).to eq 'https://s3.amazonaws.com/americanarchive.org/chapters/cpb-aacip-114-90dv49m9/cpb-aacip-114-90dv49m9.vtt'
+    end
+  end
+
+  describe '.file_present?' do
+    it 'returns true for an id with a file on S3' do
+      expect(ChapterFile.file_present?(id_1)).to eq(true)
+    end
+
+    it 'returns false for an id without a file on S3' do
+      expect(ChapterFile.file_present?(id_2)).to eq(false)
+    end
+  end
+
+  after(:all) do
+    # Re-disable WebMock so other tests can use actual connections.
+    WebMock.disable!
+  end
+end

--- a/spec/scripts/pb_core_ingester_spec.rb
+++ b/spec/scripts/pb_core_ingester_spec.rb
@@ -49,7 +49,7 @@ describe PBCoreIngester do
     Dir[glob].each do |fixture_path|
       expect { @ingester.ingest(path: fixture_path) }.not_to raise_error
     end
-    expect_results(30)
+    expect_results(31)
   end
 
   def expect_results(count)

--- a/spec/support/fixture-ignore.txt
+++ b/spec/support/fixture-ignore.txt
@@ -1,0 +1,1 @@
+spec/fixtures/pbcore/clean-has-chapters.xml


### PR DESCRIPTION
@afred - This is ready for review. It checks for a chapter file on s3 and displays the chapter button in the VideoJS player if one exists. One thing I don't like here is that I kept getting false HTML validation errors on the new fixture, so I included an option to bypass it (line 447 in catalog_spec). Essentially it kept returning that the video element doesn't have a closing tag, but it does and I could see it in the HTML returned. If you have thoughts on a better implementation for this ticket, they would be much appreciated!