### PR TITLE
Update newsmagazine links

### DIFF
--- a/app/views/exhibits/newsmagazines.md
+++ b/app/views/exhibits/newsmagazines.md
@@ -24,7 +24,7 @@ Digital Exhibits Intern, American Archive of Public Broadcasting
 - [President Lyndon B. Johnson's Remarks on the Public Broadcasting Act](http://www.cpb.org/aboutpb/act/remarks)
 - [National Public Broadcasting Archives at University of Maryland](http://www.lib.umd.edu/special/collections/massmedia/publicandeducationalbroadcasting)
 - [NET (National Educational Television) Collection at the Library of Congress](http://www.loc.gov/rr/mopic/tvcoll.html#tele)
-- [NET Collection Catalog Project](http://americanarchive.org/about-the-american-archive/projects/net-catalog), AAPB
+- [NET Collection Catalog Project from the AAPB](http://americanarchive.org/about-the-american-archive/projects/net-catalog)
 
 ## Main 
 

--- a/app/views/exhibits/newsmagazines.md
+++ b/app/views/exhibits/newsmagazines.md
@@ -21,9 +21,9 @@ Digital Exhibits Intern, American Archive of Public Broadcasting
 ## Resources
 
 - [The Public Broadcasting Act of 1967](http://www.cpb.org/aboutpb/act)
-- [Remarks on the Public Broadcasting Act](http://www.cpb.org/aboutpb/act/remarks)
-- [National Public Broadcasting Archives](http://www.lib.umd.edu/special/collections/massmedia/publicandeducationalbroadcasting), University of Maryland
-- [NET (National Educational Television) Collection](http://www.loc.gov/rr/mopic/tvcoll.html#tele), Library of Congress 
+- [President Lyndon B. Johnson's Remarks on the Public Broadcasting Act](http://www.cpb.org/aboutpb/act/remarks)
+- [National Public Broadcasting Archives at University of Maryland](http://www.lib.umd.edu/special/collections/massmedia/publicandeducationalbroadcasting)
+- [NET (National Educational Television) Collection at the Library of Congress](http://www.loc.gov/rr/mopic/tvcoll.html#tele)
 - [NET Collection Catalog Project](http://americanarchive.org/about-the-american-archive/projects/net-catalog), AAPB
 
 ## Main 

--- a/app/views/exhibits/newsmagazines.md
+++ b/app/views/exhibits/newsmagazines.md
@@ -21,9 +21,9 @@ Digital Exhibits Intern, American Archive of Public Broadcasting
 ## Resources
 
 - [The Public Broadcasting Act of 1967](http://www.cpb.org/aboutpb/act)
-- President Lyndon B. Johnson's [Remarks on the Public Broadcasting Act](http://www.cpb.org/aboutpb/act/remarks)
+- [Remarks on the Public Broadcasting Act](http://www.cpb.org/aboutpb/act/remarks)
 - [National Public Broadcasting Archives](http://www.lib.umd.edu/special/collections/massmedia/publicandeducationalbroadcasting), University of Maryland
-- NET (National Educational Television) [Collection](http://www.loc.gov/rr/mopic/tvcoll.html#tele), Library of Congress 
+- [NET (National Educational Television) Collection](http://www.loc.gov/rr/mopic/tvcoll.html#tele), Library of Congress 
 - [NET Collection Catalog Project](http://americanarchive.org/about-the-american-archive/projects/net-catalog), AAPB
 
 ## Main 


### PR DESCRIPTION
Parts of link titles weren't appearing because they weren't formatted correctly in the md.