### PR TITLE
1289: Fixes overlap in "no transcript" text

### DIFF
--- a/app/assets/stylesheets/locals/media-tablet.css.scss
+++ b/app/assets/stylesheets/locals/media-tablet.css.scss
@@ -153,4 +153,16 @@
   margin-top: 1em;
 }
 
+@media (max-width: 1200px) {
+	.no-transcript {
+		font-size: 12px !important;
+	}
+
+	.transcript-header {
+		p {
+			font-size: 12px !important;
+		}
+	}
+}
+
 }/* END: Tablet ---------- */


### PR DESCRIPTION
@afred - 

* There was Small pixel region where text overlapped
* Reduces font size from 14 to 12 for that region
* Closes #1289