### PR TITLE
1319 add library of congress

### DIFF
--- a/app/views/organizations/md/NCSG55087.md
+++ b/app/views/organizations/md/NCSG55087.md
@@ -1,0 +1,26 @@
+# Library of Congress
+
+## Short name
+
+Library of Congress
+
+## State
+
+D.C.
+
+## City
+
+Washington
+
+## Logo
+
+## Url
+
+https://www.loc.gov/
+
+## History
+
+## Productions
+
+
+

--- a/app/views/organizations/usa.svg
+++ b/app/views/organizations/usa.svg
@@ -246,7 +246,7 @@
     <a xlink:href='/participating-orgs#Colorado' tabindex="-1"><title>Boulder, CO: KGNU</title><use xlink:href='#dot' x='329' y='241'/></a>
     <a xlink:href='/participating-orgs#Colorado' tabindex="-1"><title>Denver, CO: Rocky Mountain PBS + KUVO + Colorado Public Television + University of Denver</title><use xlink:href='#dot' x='337' y='247'/></a>
     <a xlink:href='/participating-orgs#Connecticut' tabindex="-1"><title>Hartford, CT: Connecticut Public Broadcasting Network</title><use xlink:href='#dot' x='854' y='169'/></a>
-    <a xlink:href='/participating-orgs#DC' tabindex="-1"><title>Washington, DC: WHUT + NewsHour Productions + Georgetown Forum</title><use xlink:href='#dot' x='800' y='247'/></a>
+    <a xlink:href='/participating-orgs#DC' tabindex="-1"><title>Washington, DC: WHUT + NewsHour Productions + Library of Congress + Georgetown Forum</title><use xlink:href='#dot' x='800' y='247'/></a>
     <a xlink:href='/participating-orgs#Florida' tabindex="-1"><title>Tampa, FL: WUSF + WEDU</title><use xlink:href='#dot' x='745' y='499'/></a>
     <a xlink:href='/participating-orgs#Florida' tabindex="-1"><title>Jacksonville, FL: WJCT</title><use xlink:href='#dot' x='753' y='453'/></a>
     <a xlink:href='/participating-orgs#Florida' tabindex="-1"><title>Fort Myers, FL: WGCU Public Media</title><use xlink:href='#dot' x='759' y='529'/></a>


### PR DESCRIPTION
adds basic page for The Library of Congress to the list and map of Participating Organizations. When the Library sends more extensive information and a logo file, we can update the markdown.