### PR TITLE
1410 exhibit summary

### DIFF
--- a/app/assets/stylesheets/globals/exhibits.css.scss
+++ b/app/assets/stylesheets/globals/exhibits.css.scss
@@ -23,3 +23,7 @@
 .exhibit-index-title {
   font-size: 24px !important;
 }
+
+.exhibit-breadcrumb {
+  margin-top: -18px;
+}

--- a/app/views/catalog/_search_header.html.erb
+++ b/app/views/catalog/_search_header.html.erb
@@ -1,7 +1,3 @@
-<% if @exhibit %>
-  <%= render partial: 'exhibits/show_all_items_header', locals: {exhibit: @exhibit } %>
-<% end %>
-
 <%= render 'did_you_mean' %>
 
 <%= render 'constraints' %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -11,6 +11,9 @@
   <div class="page-header">
     <h1>Search Results</h1>
   </div>
+  <% if @exhibit %>
+    <%= render partial: 'exhibits/show_all_items_header', locals: {exhibit: @exhibit } %>
+  <% end %>
 <% end %>
 
 <div id="sidebar" class="col-md-3 col-sm-4">

--- a/app/views/exhibits/_show_all_items_header.html.erb
+++ b/app/views/exhibits/_show_all_items_header.html.erb
@@ -1,3 +1,9 @@
-<h4><%= link_to(exhibit.title, "/exhibits/#{exhibit.path}") %></h4>
-
-<%= sanitize(exhibit.summary_html, tags: []) %>
+<div class="row">
+  <div class="col-md-12 breadcrumb-row exhibit-breadcrumb">
+    <ol class="collection-breadcrumb hidden-xs" style="margin-top: 0px;">
+      <li><a href="/exhibits">Exhibits</a></li>
+      <li><a href="/exhibits/<%= exhibit.path %>"><%= exhibit.title %></a></li>
+      <li>Search</li>
+    </ol>
+  </div>
+</div>

--- a/spec/aws/s3_spec.rb
+++ b/spec/aws/s3_spec.rb
@@ -18,7 +18,7 @@ describe 'S3' do
   end
   describe 'policy effect' do
     it 'allows thumbnail without referer' do
-      curl = Curl::Easy.http_get('https://s3.amazonaws.com/americanarchive.org/thumbnail/cpb-aacip-41-644qrtnj.jpg')
+      curl = Curl::Easy.http_get('https://s3.amazonaws.com/americanarchive.org/thumbnail/cpb-aacip_41-644qrtnj.jpg')
       curl.perform
       expect(curl.status).to eq('200 OK')
     end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -226,16 +226,16 @@ describe 'Catalog' do
 
       describe 'exhibit facet' do
         describe 'in gallery' do
-          it 'has exhibit description' do
+          it 'has exhibit breadcrumb' do
             visit '/catalog?f[exhibits][]=station-histories&view=gallery&f[access_types][]=' + PBCore::ALL_ACCESS
-            expect(page).to have_text('Every public broadcasting station')
+            expect(page).to have_text('Documenting and Celebrating Public Broadcasting Station Histories')
           end
         end
 
         describe 'in list' do
-          it 'has exhibit description' do
+          it 'has exhibit breadcrumb' do
             visit '/catalog?f[exhibits][]=station-histories&view=list&f[access_types][]=' + PBCore::ALL_ACCESS
-            expect(page).to have_text('Every public broadcasting station')
+            expect(page).to have_text('Documenting and Celebrating Public Broadcasting Station Histories')
           end
         end
       end


### PR DESCRIPTION
Removes Exhibit summary from the top of the Search Results index and replaces with Exhibits breadcrumbs. Also fixes test that was broken by renaming thumbnail (properly) on S3.