### PR TITLE
Search Results Spinner from Exhibits and Special Collections

### DIFF
--- a/app/views/exhibits/show.html.erb
+++ b/app/views/exhibits/show.html.erb
@@ -42,7 +42,7 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-9"><h3><%= @exhibit.title %></h3></div>
-          <div class="col-sm-3"><a class="btn btn-primary" href="<%= '/catalog?sort=year+asc&f[exhibits][]=' + @exhibit.path %>">Show All Items</a></div>
+          <div class="col-sm-3"><a class="btn btn-primary" href="<%= '/catalog?sort=year+asc&f[exhibits][]=' + @exhibit.path %>" data-no-turbolink='true'>Show All Items</a></div>
         </div>
       </div>
     </div>

--- a/app/views/special_collections/_collection_search.html.erb
+++ b/app/views/special_collections/_collection_search.html.erb
@@ -28,7 +28,7 @@
 
       <% end %>
       <div class="collection-all-btn">
-        <a class="btn btn-primary view-all-shadow" href="<%= '/catalog?sort=year+asc&f[special_collection][]=' + @special_collection.path %>">View the collection</a>
+        <a class="btn btn-primary view-all-shadow" href="<%= '/catalog?sort=year+asc&f[special_collection][]=' + @special_collection.path %>" data-no-turbolink='true'>View the collection</a>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Noticed the spinner for search results loading wasn't getting triggered off from links on Exhibits and Special Collections due to turbolinks. This fixes that.