### PR TITLE
ORR Whitelist for meptest.dartmouth.edu

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,7 @@ class Ability
 
     can :play, PBCore do |pbcore|
       (user.onsite? && (pbcore.public? || pbcore.protected?)) || # Comment out for developing TOS features.
-        (user.usa? && !user.bot? && user.affirmed_tos? && pbcore.public?)
+        (user.usa? && !user.bot? && (user.affirmed_tos? || user.authorized_referer?) && pbcore.public?)
     end
 
     cannot :skip_tos, PBCore do |pbcore|
@@ -14,8 +14,8 @@ class Ability
         !user.affirmed_tos? && user.usa? && !user.bot? && pbcore.public?
     end
 
-    can :access_media_url, PBCore do
-      user.onsite? || user.aapb_referer? || user.embed?
+    can :access_media_url, PBCore do |pbcore|
+      user.onsite? || user.aapb_referer? || user.embed? || (user.authorized_referer? && pbcore.public?)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ require 'ipaddr'
 require_relative '../../lib/geo_i_p_country'
 
 class User
+  DARTMOUTH_HOST_RE = /^(.+\.)?meptest\.dartmouth\.edu$/
   POPUP_HOST_RE = /^(.+\.)?popuparchive\.com$/
   AAPB_HOST_RE = /^(.+\.)?americanarchive\.org$/
   AWS_HOST_RE = /^(.+\.)?wgbh-mla\.org$/
@@ -41,6 +42,12 @@ class User
     end
   end
 
+  def authorized_referer?
+    authorized_referer_regexes.any? do |authorized_referer_regex|
+      referer_host =~ authorized_referer_regex
+    end
+  end
+
   def embed?
     URI.parse(request.referer).path =~ /embed/
   end
@@ -53,6 +60,10 @@ class User
 
   def aapb_referer_regexes
     [AAPB_HOST_RE, POPUP_HOST_RE, AWS_HOST_RE]
+  end
+
+  def authorized_referer_regexes
+    [DARTMOUTH_HOST_RE]
   end
 
   def onsite_ip_ranges

--- a/spec/models/abilities/pbcore/can_access_media_url_spec.rb
+++ b/spec/models/abilities/pbcore/can_access_media_url_spec.rb
@@ -96,11 +96,23 @@ describe Ability do
         end
       end
 
-      context 'when User is not on-site; User is not an AAPB referer; User is not embedding the media' do
-        let(:user) { instance_double(User, 'onsite?' => false, 'aapb_referer?' => false, 'embed?' => false) }
+      context 'when User is not on-site; User is not an AAPB referer; User is not embedding the media; User is not an authorized referer' do
+        let(:user) { instance_double(User, 'onsite?' => false, 'aapb_referer?' => false, 'embed?' => false, 'authorized_referer?' => false) }
 
         it 'returns false for public PBCore records' do
           expect(ability).to_not be_able_to(:access_media_url, public_pbcore_record)
+        end
+
+        it 'returns false for protected PBCore records' do
+          expect(ability).to_not be_able_to(:access_media_url, protected_pbcore_record)
+        end
+      end
+
+      context 'when User is not on-site; User is not an AAPB referer; User is not embedding the media; User is an authorized referer' do
+        let(:user) { instance_double(User, 'onsite?' => false, 'aapb_referer?' => false, 'embed?' => false, 'authorized_referer?' => true) }
+
+        it 'returns true for public PBCore records' do
+          expect(ability).to be_able_to(:access_media_url, public_pbcore_record)
         end
 
         it 'returns false for protected PBCore records' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -100,6 +100,41 @@ describe User do
     end
   end
 
+  describe '#authorized_referer?' do
+    @authorized_referers = [
+      'http://meptest.dartmouth.edu'
+    ]
+
+    @authorized_referers.each do |auth_referer|
+      context "when the referer is '#{auth_referer}'" do
+        # Stub the fake request to return the referer we're trying to test.
+        before { allow(fake_request).to receive(:referer) { auth_referer } }
+
+        it 'returns true' do
+          expect(user.authorized_referer?).to eq true
+        end
+      end
+    end
+
+    @non_authorized_referers = [
+      'http://example.com',
+      'http://123.123.123.123',
+      'this is not even a URI',
+      nil
+    ]
+
+    @non_authorized_referers.each do |non_auth_referer|
+      context "when the referer is '#{non_auth_referer}'" do
+        # Stub the fake request to return the referer we're trying to test.
+        before { allow(fake_request).to receive(:referer) { non_auth_referer } }
+
+        it 'returns false' do
+          expect(user.authorized_referer?).to eq false
+        end
+      end
+    end
+  end
+
   describe 'abilities' do
     examples = {
       public:    PBCore.new(File.read('./spec/fixtures/pbcore/access-level-public.xml')),

--- a/spec/support/link-check-ignore.txt
+++ b/spec/support/link-check-ignore.txt
@@ -193,3 +193,7 @@ http://hdl.handle.net/2027/mdp.39015010331760
 /special_collections/american-masters-interviews
 /special_collections/eotp-i-interviews
 /special_collections/ken-burns-civil-war
+https://current.org/2007/11/president-johnsons-remarks-on-signing-the-public-broadcasting-act-1967/
+https://current.org/wp-content/uploads/archive-site/prog/prog717n.html
+https://current.org/wp-content/uploads/archive-site/prog/prog523n.html
+


### PR DESCRIPTION
@afred - Could you take a look at this PR? It closes #1149 for turning off referrer checks for assets that have an annotation "Level of User Access ="Online Reading Room" for the domain meptest.dartmouth.edu. I think this should do trick, but if you could take a closer look at the user.rb updates to confirm it would be much appreciated since this is hard to manually test.

In addition, I've reached out to the Dartmouth contact about a manual test from their end where I get them access to my local machine using the ngrok service I've used in the past.