### PR TITLE
Removes transcript_ready? check in place for api_controller

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -199,13 +199,9 @@ class PBCore # rubocop:disable Metrics/ClassLength
   rescue NoMatchError
     nil
   end
-  def transcript_ready?
-    return true if transcript_status == PBCore::ORR_TRANSCRIPT || transcript_status == PBCore::ON_LOCATION_TRANSCRIPT
-    false
-  end
   def transcript_content
-    return TranscriptFile.new(id).json if transcript_ready? && TranscriptFile.json_file_present?(id)
-    return TranscriptFile.new(id).text if transcript_ready? && TranscriptFile.text_file_present?(id)
+    return TranscriptFile.new(id).json if TranscriptFile.json_file_present?(id)
+    return TranscriptFile.new(id).text if TranscriptFile.text_file_present?(id)
     return CaptionFile.new(id).json if CaptionFile.file_present?(id)
     nil
   end

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -170,7 +170,6 @@ describe 'Validated and plain PBCore' do
         # Doing this because the CaptionFile associated with this PB Core fixture is suspect at best and don't have time to change everywhere it is used.
         transcript_content: "{\"language\":\"en-US\",\"parts\":[{\"text\":\"Raw bytes 0-255 follow: \\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b \\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f !\\\"\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F\u0080\u0081\u0082\u0083\u0084\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008D\u008E\u008F\u0090\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009D\u009E\u009F ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ\",\"start_time\":\"0.0\",\"end_time\":\"20.0\"}]}",
         # rubocop:enable LineLength
-        transcript_ready?: false,
         transcript_src: nil,
         transcript_status: nil,
         organization_pbcore_name: 'WGBH',
@@ -220,15 +219,13 @@ describe 'Validated and plain PBCore' do
           'id' => 'cpb-aacip_111-21ghx7d6',
           'player_aspect_ratio' => '4:3',
           'player_specs' => %w(680 510),
-          'transcript_status' => 'Online Reading Room Transcript',
-          'transcript_ready?' => true
+          'transcript_status' => 'Online Reading Room Transcript'
         }
         attrs = {
           'id' => pbc.id,
           'player_aspect_ratio' => pbc.player_aspect_ratio,
           'player_specs' => pbc.player_specs,
-          'transcript_status' => pbc.transcript_status,
-          'transcript_ready?' => pbc.transcript_ready?
+          'transcript_status' => pbc.transcript_status
         }
 
         expect(expected_attrs).to eq(attrs)


### PR DESCRIPTION
This will allow the api_controller to show all transcripts of any status per requirement laid out in #1458.

* Closes #1458