### PR TITLE
1470 No Contributor

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -82,7 +82,11 @@ class Organization < Cmless
   end
 
   def self.organizations(organization_names)
-    organization_names.map { |org| Organization.find_by_pbcore_name(org) }
+    organization_names.map { |org| Organization.find_by_pbcore_name(org) }.compact
+  end
+
+  def self.build_organization_names_display(organizations)
+    organizations.map { |org| org.short_name_html.gsub(/<[^>]*>/, '') }
   end
 
   def to_a

--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -148,13 +148,13 @@ class PBCore # rubocop:disable Metrics/ClassLength
     @organization_names ||= xpaths('/*/pbcoreAnnotation[@annotationType="organization"]')
   end
   def organizations_facet
-    @organizations_facet ||= Organization.organizations(organization_names).map(&:facet)
+    @organizations_facet ||= organization_objects.map(&:facet) unless organization_objects.empty?
   end
   def organization_objects
     @organization_objects ||= Organization.organizations(organization_names)
   end
   def organization_names_display
-    @organization_names_display ||= organization_names.join(', ')
+    @organization_names_display ||= Organization.build_organization_names_display(organization_objects)
   end
   def states
     @states ||= @organization_objects.map(&:state)

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -42,10 +42,12 @@
               </dl>
             <% end %>
 
-            <dl class="clearfix">
-              <dt>Organization</dt>
-              <dd><%= pbcore.organization_names_display %></dd>
-            </dl>
+            <% unless pbcore.organization_names_display.empty? %>
+              <dl class="clearfix">
+                <dt>Organization</dt>
+                <dd><%= pbcore.organization_names_display.join(', ') %></dd>
+              </dl>
+            <% end %>
 
             <% if params[:q].present? && pbcore.captions_src != nil %>
               <% CaptionFile.new(pbcore.id).captions_from_query(@query_for_captions).tap do |caption| %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -232,7 +232,7 @@
     <dl>
       <% url = "http://americanarchive.org/catalog/#{@pbcore.id}" %>
       <% today = Date.today.to_formatted_s(:long) %>
-      <% org = ( @pbcore.organization_names_display.first.nil? ? '' : @pbcore.organization_names_display.first + ', ' ) + 'American Archive of Public Broadcasting (WGBH and the Library of Congress), Boston, MA and Washington, DC' %>
+      <% org = ( @pbcore.organization_names_display.empty? ? '' : @pbcore.organization_names_display.join(', ') + ', ' ) + 'American Archive of Public Broadcasting (WGBH and the Library of Congress), Boston, MA and Washington, DC' %>
 
       <dt>Citation</dt>
       <dd><em>Chicago</em>:

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -69,8 +69,10 @@
           Please note: This content is only available at
           the Library of Congress. For information about on location research,
           <a href="/on-location">click here</a>.
-        <% elsif !@pbcore.digitized? %>
+        <% elsif !@pbcore.digitized? && !@pbcore.organization_objects.empty? %>
           This content has not been digitized. Please contact the contributing organization(s) listed below.
+        <% elsif !@pbcore.digitized? && @pbcore.organization_objects.empty? %>
+          This content has not been digitized.
         <% end %>
 
         <% @pbcore.reference_urls.each do |url| %>
@@ -100,13 +102,15 @@
       </dl>
     <% end %>
 
-    <dl>
-      <dt>Contributing Organization</dt>
-      <% @pbcore.organization_objects.each do |org|%>
-        <dd><a href='/participating-orgs/<%= url_encode(org.id) %>'><%= org.short_name %></a>
-        (<%= org.city %>, <%= org.state %>)</dd>
-      <% end %>
-    </dl>
+    <% unless @pbcore.organization_objects.empty? %>
+      <dl>
+        <dt>Contributing Organization</dt>
+        <% @pbcore.organization_objects.each do |org|%>
+          <dd><a href='/participating-orgs/<%= url_encode(org.id) %>'><%= org.short_name %></a>
+          (<%= org.city %>, <%= org.state %>)</dd>
+        <% end %>
+      </dl>
+    <% end %>
 
     <% @pbcore.ids.each do |type,id| %>
       <dl>
@@ -224,10 +228,12 @@
       </dl>
     <% end %>
 
+
     <dl>
       <% url = "http://americanarchive.org/catalog/#{@pbcore.id}" %>
       <% today = Date.today.to_formatted_s(:long) %>
-      <% org = @pbcore.organization_objects.first.short_name_html.gsub(/<[^>]*>/, '').html_safe + ', American Archive of Public Broadcasting (WGBH and the Library of Congress), Boston, MA and Washington, DC' %>
+      <% org = ( @pbcore.organization_names_display.first.nil? ? '' : @pbcore.organization_names_display.first + ', ' ) + 'American Archive of Public Broadcasting (WGBH and the Library of Congress), Boston, MA and Washington, DC' %>
+
       <dt>Citation</dt>
       <dd><em>Chicago</em>:
         &ldquo;<%= @pbcore.title %>,&rdquo;

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -29,8 +29,8 @@ describe 'API' do
       expect(page).to have_text('my_callback({ "responseHeader"')
       expect(page).to have_text('"rows": "0"')
       expect(page).to have_text('"year:1988 AND iowa": 1')
-      expect(page).to have_text('"numFound": 37')
-      expect(page).to have_text('"1974", 3, "1987", 2, "1958", 1, "1981", 1, "1983", 1, "1988", 1, "1990", 1, "1992", 1, "2000", 1, "2003", 1')
+      expect(page).to have_text('"numFound": 38')
+      expect(page).to have_text('"1974", 3, "1987", 2, "1958", 1, "1961", 1, "1981", 1, "1983", 1, "1988", 1, "1990", 1, "1992", 1, "2000", 1, "2003", 1')
     end
 
     it 'searches documents / json, not jsonp' do

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -122,7 +122,7 @@ describe 'Catalog' do
           ['asset_type', 1, 'Segment', 8],
           ['organizations', 41, 'WGBH+(MA)', 6], # tag ex and states mean lots of facet values.
           ['year', 1, '2000', 1],
-          ['access_types', 3, PBCore::ALL_ACCESS, 37]
+          ['access_types', 3, PBCore::ALL_ACCESS, 38]
         ]
         it 'has them all' do
           visit "/catalog?f[access_types][]=#{PBCore::ALL_ACCESS}"
@@ -189,7 +189,7 @@ describe 'Catalog' do
           expect(page).to have_text('You searched for: Access online')
 
           click_link('All Records')
-          expect_count(37)
+          expect_count(38)
           expect(page).to have_text('You searched for: Access all')
 
           click_link('KQED (CA)')
@@ -252,7 +252,7 @@ describe 'Catalog' do
           # rubocop:disable LineLength
           assertions = [
             ['Iowa', ['Touchstone 108', 'Dr. Norman Borlaug; B-Roll', 'Musical Encounter; 116; Music for Fun', 'Bob Brozman', 'The Civil War; Interviews with Barbara Fields']],
-            ['art', ['The Scheewe Art Workshop', 'Unknown', 'A Sorting Test: 100', 'Musical Performance of Appalachian Folk Music in Kentucky', '15th Anniversary Show']],
+            ['art', ['The Scheewe Art Workshop', 'Unknown', 'Origami; 7; Paper Ball', 'A Sorting Test: 100', 'Musical Performance of Appalachian Folk Music in Kentucky', '15th Anniversary Show']],
             ['John', ['World Cafe; Larry Kane On John Lennon 2005', 'Dr. Norman Borlaug; B-Roll', 'The Civil War; Interview with Daisy Turner', 'The Civil War; Interviews with Barbara Fields', 'Musical Performance of Appalachian Folk Music in Kentucky', '15th Anniversary Show']]
           ]
           # rubocop:enable LineLength
@@ -307,7 +307,7 @@ describe 'Catalog' do
                 end.select { |x| x }.join('; ')
               end.join("\n")).to eq([
                 ['Program: Ask Governor Chris Gr', 'Organization: KUOW Puget Sound Publ', 'Media Type: Sound', 'Access: '],
-                ['Series: Askc: Ask Congress', 'Episode: #508', 'Organization: WHUT-TV (Howard Unive', 'Media Type: other', 'Access: '],
+                ['Series: Askc: Ask Congress', 'Episode: #508', 'Organization: WHUT', 'Media Type: other', 'Access: '],
                 ['Program: Bob Brozman; Organization: Iowa Public Radio', 'Media Type: Sound', 'Access: Accessible on locatio'],
                 ['Series: The Civil War; Raw Footage: Interview with Daisy', 'Created: 1987-05-21', 'Organization: Ken Burns - Florentin', 'Media Type: Moving Image', 'Access: Online Reading Room'],
                 ['Series: The Civil War; Raw Footage: Interviews with Barba', 'Created: 1987-01-14', 'Organization: Ken Burns - Florentin', 'Media Type: Moving Image', 'Access: Online Reading Room'],
@@ -315,34 +315,35 @@ describe 'Catalog' do
                 ['Raw Footage: Dr. Norman Borlaug', 'Raw Footage: B-Roll', 'Organization: Iowa Public Televisio', 'Media Type: Moving Image', 'Access: '],
                 ['Title: Dry Spell', 'Organization: KQED', 'Media Type: Moving Image', 'Access: '],
                 ['Program: Four Decades of Dedic', 'Title: Handles missing title', 'Organization: WPBS', 'Media Type: Moving Image', 'Access: '],
-                ['Title: From Bessie Smith to', 'Created: 1990-07-27', 'Date: 1991-07-27', 'Organization: Film & Media Archive,', 'Media Type: Moving Image', 'Access: '],
-                ['Series: Gvsports', 'Organization: WGVU Public TV & Radi', 'Media Type: other', 'Access: '],
+                ['Title: From Bessie Smith to', 'Created: 1990-07-27', 'Date: 1991-07-27', 'Organization: Film and Media Archiv', 'Media Type: Moving Image', 'Access: '],
+                ['Series: Gvsports', 'Organization: WGVU Public TV and Ra', 'Media Type: other', 'Access: '],
                 ['Series: The Lost Year', 'Organization: Arkansas Educational', 'Media Type: Moving Image', 'Access: Accessible on locatio'],
                 ['Series: The MacNeil/Lehrer Ne', 'Date: 1983-10-13', 'Organization: NewsHour Productions', 'Media Type: Moving Image', 'Access: Online Reading Room'],
                 ['Series: Making It Here; Episode Number: 105; Episode: Sweets', 'Date: 2003-01-22', 'Organization: WGBY', 'Media Type: Moving Image', 'Access: Online Reading Room'],
                 ['Raw Footage: MSOM Field Tape - BUG', 'Organization: Maryland Public Telev', 'Media Type: Moving Image', 'Access: '],
                 ['Episode Number: Musical Encounter', 'Episode Number: 116', 'Episode Number: Music for Fun', 'Created: 1988-05-12', 'Organization: Iowa Public Televisio', 'Media Type: Moving Image',
                  'Access: Online Reading Room'],
-                ['Raw Footage: Musical Performance o', 'Created: 1992-06-05', 'Organization: Appalshop, Inc. (WMMT', 'Media Type: Sound', 'Access: Accessible on locatio'],
+                ['Raw Footage: Musical Performance o', 'Created: 1992-06-05', 'Organization: Appalshop, Inc.', 'Media Type: Sound', 'Access: Accessible on locatio'],
                 ['Series: Nixon Impeachment Hea', 'Episode Number: 2', 'Episode: 1974-07-24', 'Segment: Part 1 of 3', 'Broadcast: 1974-07-24', 'Organization: WGBH', 'Media Type: Moving Image', 'Access: Online Reading Room'],
                 ['Series: Nixon Impeachment Hea', 'Episode Number: 2', 'Episode: 1974-07-24', 'Segment: Part 2 of 3', 'Broadcast: 1974-07-24', 'Organization: WGBH', 'Media Type: Moving Image', 'Access: Online Reading Room'],
                 ['Series: Nixon Impeachment Hea', 'Episode Number: 2', 'Episode: 1974-07-24', 'Segment: Part 3 of 3', 'Broadcast: 1974-07-24', 'Organization: WGBH', 'Media Type: Moving Image', 'Access: Online Reading Room'],
                 ['Series: Nova', 'Program: Gratuitous Explosions', 'Episode Number: 3-2-1', 'Episode: Kaboom!', 'Date: 2000-01-01', 'Organization: WGBH', 'Media Type: Moving Image', 'Access: Online Reading Room'],
+                ['Series: Origami; Episode Number: 7', 'Episode: Paper Ball', 'Broadcast: 1961-00-00', 'Media Type: other', 'Access: '],
                 ['Title: Podcast Release Form', 'Organization: KXCI Community Radio', 'Media Type: other', 'Access: '],
                 ['Title: Racing the Rez', 'Organization: Vision Maker Media', 'Media Type: Moving Image', 'Access: Accessible on locatio'],
                 ['Series: Reading Aloud', 'Program: MacLeod: The Palace G', 'Organization: WGBH', 'Media Type: Sound', 'Access: '],
                 ['Title: The Scheewe Art Works', 'Organization: Detroit Public Televi', 'Media Type: Moving Image', 'Access: '],
                 ['Program: The Sorting Test: 1', 'Organization: WUSF', 'Media Type: other', 'Access: '],
                 ['Program: # "SORTING" Test: 2', 'Organization: Detroit Public Televi', 'Media Type: Moving Image', 'Access: '],
-                ['Program: A Sorting Test: 100', 'Organization: WNYC-FM', 'Media Type: Moving Image', 'Access: '],
+                ['Program: A Sorting Test: 100', 'Organization: WNYC', 'Media Type: Moving Image', 'Access: '],
                 ['Episode: Touchstone 108', 'Organization: Iowa Public Televisio', 'Media Type: Moving Image', 'Access: '],
-                ['Program: Unknown', 'Organization: WIAA-FM', 'Media Type: Sound', 'Access: '],
+                ['Program: Unknown', 'Organization: WIAA', 'Media Type: Sound', 'Access: '],
                 ['Program: Winston Churchill Obi', 'Broadcast: 1958-00-00', 'Organization: Library of Congress,', 'Media Type: Moving Image', 'Access: '],
-                ['Program: World Cafe', 'Segment: Howard Kramer 2004', 'Organization: WXPN-FM', 'Media Type: Sound', 'Access: '],
-                ['Program: World Cafe', 'Segment: Larry Kane On John Le', 'Organization: WXPN-FM', 'Media Type: Sound', 'Access: '],
-                ['Program: World Cafe', 'Segment: 1997-01-20 Sat/Mon', 'Segment: Martin Luther King, J', 'Organization: WXPN-FM', 'Media Type: Sound', 'Access: '],
-                ['Collection: WQXR', 'Series: This is My Music', 'Episode: Judd Hirsch', 'Organization: WNYC-FM', 'Media Type: Sound', 'Access: '],
-                ['Series: Writers Forum', 'Program: WRF-09/13/07', 'Copyright Date: 2007-09-13', 'Organization: WERU-FM (WERU Communi', 'Media Type: Sound', 'Access: '],
+                ['Program: World Cafe', 'Segment: Howard Kramer 2004', 'Organization: WXPN', 'Media Type: Sound', 'Access: '],
+                ['Program: World Cafe', 'Segment: Larry Kane On John Le', 'Organization: WXPN', 'Media Type: Sound', 'Access: '],
+                ['Program: World Cafe', 'Segment: 1997-01-20 Sat/Mon', 'Segment: Martin Luther King, J', 'Organization: WXPN', 'Media Type: Sound', 'Access: '],
+                ['Collection: WQXR', 'Series: This is My Music', 'Episode: Judd Hirsch', 'Organization: WNYC', 'Media Type: Sound', 'Access: '],
+                ['Series: Writers Forum', 'Program: WRF-09/13/07', 'Copyright Date: 2007-09-13', 'Organization: WERU Community Radio', 'Media Type: Sound', 'Access: '],
                 ['Program: 15th Anniversary Show', 'Created: 1981-12-05', 'Organization: Arkansas Educational', 'Media Type: Moving Image', 'Access: Accessible on locatio']
               ].map { |x| x.join('; ') }.join("\n"))
             expect_fuzzy_xml

--- a/spec/fixtures/pbcore/clean-no-instantiation-location.xml
+++ b/spec/fixtures/pbcore/clean-no-instantiation-location.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pbcoreDescriptionDocument xmlns="http://www.pbcore.org/PBCore/PBCoreNamespace.html" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd">
+  <pbcoreAssetType>Episode</pbcoreAssetType>
+  <pbcoreAssetDate dateType="broadcast">1961-00-00</pbcoreAssetDate>
+  <pbcoreIdentifier source="http://americanarchiveinventory.org">cpb-aacip/516-h98z893992</pbcoreIdentifier>
+  <pbcoreIdentifier source="NOLA Code">ORIG</pbcoreIdentifier>
+  <pbcoreIdentifier source="NET_CATALOG">FMP_3182512</pbcoreIdentifier>
+  <pbcoreTitle titleType="Episode">Paper Ball</pbcoreTitle>
+  <pbcoreTitle titleType="Episode Number">7</pbcoreTitle>
+  <pbcoreTitle titleType="Series">Origami</pbcoreTitle>
+  <pbcoreDescription descriptionType="Episode Description">One of the more difficult origami subjects is the paper ball, and it is to this that Mr. Mikami devotes the episode. After demonstrating its construction a number of times, he inflates the ones he has made. They can be used, he says, for decorations or games of catch (or, NET comments, Japanese Easter eggs). Running time: 29:00. (Description adapted from documents in the NET Microfiche)</pbcoreDescription>
+  <pbcoreDescription descriptionType="Series Description">With Americas increasing interest in the Orient, and particularly in Japan, it is appropriate for National Educational Television to bring to its viewers another series devoted to traditional Japanese art forms - in this case, origami, the art of paper folding. The host on this series is Takahiko Mikami, who turns from brush painting to another delicate, sparse and subtle form of art, origami. The basis for this art is a square piece of paper, which, without scissors or glue, can be folded into all sorts of shapes, suggesting birds, fish, animals and toys -- easy to make and fun to play with. Mr. Mikami devotes each episode to one of the traditional subjects  boats, fox, crane, balloon -- and demonstrates carefully how each is made. He also describes, whenever it is appropriate, Japanese history, art and civilization. At the beginning and end of each episode, the theme music, a traditional Japanese air, is played on the koto, a stringed instrument, by Miss Akiko Hirabayashi of Palo Alto, California. Artist Takahiko Mikami has been seen by NET audiences across the country in three different series: Japanese Brush Painting, Once Upon a Japanese Time, and Whats New. Besides being a star performer for National Educational Television, he was the director of the Japanese Art Center in San Francisco. He graduated from Meiji University in Tokyo and the National Academy School of Fine Arts in New York City. He taught art in Japan and in the United States and had several one-man shows in New York, San Francisco and St. Louis. The 10 half-hour episodes that comprise this series were originally recorded on videotape. (Description adapted from documents in the NET Microfiche)</pbcoreDescription>
+  <pbcoreGenre source="AAPB Topical Genre">Fine Arts</pbcoreGenre>
+  <pbcoreGenre source="AAPB Topical Genre">Race and Ethnicity</pbcoreGenre>
+  <pbcoreGenre>Instructional</pbcoreGenre>
+  <pbcoreCreator>
+    <creator affiliation=" http://id.loc.gov/authorities/names/n50059291">KQED-TV (Television station : San Francisco, Calif.)</creator>
+    <creatorRole>Producer</creatorRole>
+  </pbcoreCreator>
+  <pbcoreContributor>
+    <contributor>Mikami, Takahiko</contributor>
+    <contributorRole>Host</contributorRole>
+  </pbcoreContributor>
+  <pbcoreContributor>
+    <contributor>Hirabayashi, Akiko</contributor>
+    <contributorRole>Performer</contributorRole>
+  </pbcoreContributor>
+  <pbcoreAnnotation annotationType="MAVIS Number">2459438</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="MAVIS Number">2459439</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="last_modified">2018-04-10 16:05:11</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType="organization">No AAPB Contributor</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../app/models/organization'
 
 describe Organization do
+  let(:wgbh) { Organization.find_by_pbcore_name('WGBH') }
+  let(:loc) { Organization.find_by_pbcore_name('Library of Congress') }
+
   it 'contains expected data' do
     org = Organization.find_by_pbcore_name('WGBH')
     expect(org.pbcore_name).to eq('WGBH')
@@ -8,5 +11,21 @@ describe Organization do
     expect(org.id).to eq('1784.2')
     expect(org.city).to eq('Boston')
     expect(org.state).to eq('Massachusetts')
+  end
+
+  describe '.organizations' do
+    it 'returns an array of organization objects from an array of organization names' do
+      expect(Organization.organizations(['WGBH', 'Library of Congress'])).to eq([wgbh, loc])
+    end
+
+    it 'filters out any organizations that cannot be found' do
+      expect(Organization.organizations(['WGBH', 'Bunk Org', 'Library of Congress'])).to eq([wgbh, loc])
+    end
+  end
+
+  describe '.build_organization_names_display' do
+    it 'returns an array of organization short names from an array of organization objects' do
+      expect(Organization.build_organization_names_display([wgbh, loc])).to eq(['WGBH', 'Library of Congress'])
+    end
   end
 end

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -198,7 +198,7 @@ describe 'Validated and plain PBCore' do
         publishers: [PBCoreNameRoleAffiliation.new('publisher', 'Moe', 'hair', 'Stooges')],
         organization_names: ['WGBH'],
         organizations_facet: ['WGBH (MA)'],
-        organization_names_display: 'WGBH',
+        organization_names_display: ['WGBH'],
         organization_objects: [Organization.find_by_pbcore_name('WGBH')],
         states: ['Massachusetts']
       }

--- a/spec/scripts/pb_core_ingester_spec.rb
+++ b/spec/scripts/pb_core_ingester_spec.rb
@@ -49,7 +49,7 @@ describe PBCoreIngester do
     Dir[glob].each do |fixture_path|
       expect { @ingester.ingest(path: fixture_path) }.not_to raise_error
     end
-    expect_results(37)
+    expect_results(38)
   end
 
   def expect_results(count)


### PR DESCRIPTION
@afred @sroosa - Since (per conversation on the ticket) we had to have something exported as an organization from the AMS in the PBCore xml, I implemented this as follows. We look at

`xpaths('/*/pbcoreAnnotation[@annotationType="organization"]')`

and then look for a matching organization. If none are found we don't display any organization information about the record.

This PR also has a small tweak in a separate commit for #1471. Originally it just used the first associated org for the citation. Now it uses all.

Closes #1470.