### PR TITLE
Limits IDs in view to AAPB and NOLA

### DIFF
--- a/app/models/pb_core.rb
+++ b/app/models/pb_core.rb
@@ -102,6 +102,9 @@ class PBCore # rubocop:disable Metrics/ClassLength
   def ci_ids
     @ci_ids ||= xpaths("/*/pbcoreIdentifier[@source='#{SONY_CI}']")
   end
+  def display_ids
+    @display_ids ||= ids.keep_if { |i| i[0] == 'AAPB ID' || i[0].downcase.include?('nola') }
+  end
   def media_srcs
     @media_srcs ||= (1..ci_ids.count).map { |part| "/media/#{id}?part=#{part}" }
   end
@@ -402,7 +405,7 @@ class PBCore # rubocop:disable Metrics/ClassLength
     ignores = [
       :text, :to_solr, :contribs, :img_src, :media_srcs,
       :captions_src, :transcript_src, :rights_code,
-      :access_level, :access_types, :title, :ci_ids,
+      :access_level, :access_types, :title, :ci_ids, :display_ids,
       :instantiations, :outside_url,
       :reference_urls, :exhibits, :special_collection, :access_level_description,
       :img_height, :img_width, :player_aspect_ratio,

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -108,7 +108,7 @@
       <% end %>
     </dl>
 
-    <% @pbcore.ids.each do |type,id| %>
+    <% @pbcore.display_ids.each do |type,id| %>
       <dl>
         <dt><%= type %></dt>
         <dd><%= id %></dd>

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -377,10 +377,16 @@ describe 'Catalog' do
 
     def expect_all_the_text(fixture_name)
       target = PBCore.new(File.read('spec/fixtures/pbcore/' + fixture_name))
+
+      # This text from the PBCore model is included in to_solr for
+      # search purposes, but excluded from view.
+      text_ignores = [target.ids].flatten
+
       # #text is only used for #to_solr, so it's private...
       # so we need the #send to get at it.
       target.send(:text).each do |field|
         field.gsub!('cpb-aacip_', 'cpb-aacip/') if field =~ /^cpb-aacip/ # TODO: Remove when we sort out ID handling.
+        next if text_ignores.include?(field)
         expect(page).to have_text(field)
       end
     end

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -161,6 +161,7 @@ describe 'Validated and plain PBCore' do
         topics: ['Music'],
         id: '1234',
         ids: [['AAPB ID', '1234'], ['somewhere else', '5678']],
+        display_ids: [['AAPB ID', '1234']],
         ci_ids: ['a-32-digit-hex', 'another-32-digit-hex'],
         media_srcs: ['/media/1234?part=1', '/media/1234?part=2'],
         img_height: 225,


### PR DESCRIPTION
@afred - this PR limits the IDs shown in the catalog#show view to just AAPB or NOLA ID codes. In particular take a look at the change in catalog_spec.rb please. This was the easiest/fastest way I could think to get around the issue of using our to_solr method to test our views. But I definitely think that is something we should change.

* Closes #1421