### PR TITLE
Creates new Ability for transcript_access

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -52,7 +52,7 @@ class ApiController < ApplicationController
     @pbcore = PBCore.new(xml)
     content = @pbcore.transcript_content
 
-    if can?(:play, @pbcore) && !content.nil?
+    if can?(:access_transcript, @pbcore) && !content.nil?
       render json: content, status: :ok
     else
       render_no_transcript_content

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,5 +17,10 @@ class Ability
     can :access_media_url, PBCore do |pbcore|
       user.onsite? || user.aapb_referer? || user.embed? || (user.authorized_referer? && pbcore.public?)
     end
+
+    can :access_transcript, PBCore do |pbcore|
+      user.onsite? || # Comment out for developing TOS features.
+        (pbcore.transcript_status == PBCore::ORR_TRANSCRIPT || (pbcore.transcript_status == PBCore::INDEXING_TRANSCRIPT && pbcore.public?))
+    end
   end
 end

--- a/spec/models/abilities/pbcore/can_access_transcript_spec.rb
+++ b/spec/models/abilities/pbcore/can_access_transcript_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe Ability do
+  # The 'user' is set with let(:user) in the contexts below.
+  subject(:ability) { Ability.new(user) }
+
+  context 'for PBCore records with transcripts' do
+    let(:pbcore_orr_transcript) { PBCore.new(File.read('./spec/fixtures/pbcore/clean-text-transcript.xml')) }
+    let(:pbcore_indexing_transcript) { PBCore.new(File.read('./spec/fixtures/pbcore/clean-transcript.xml')) }
+
+    context 'when User is offsite' do
+      let(:user) { instance_double(User, 'onsite?' => false, 'aapb_referer?' => false, 'embed?' => false, 'authorized_referer?' => true) }
+
+      it 'access_transcript returns true for an ORR transcript' do
+        expect(ability).to be_able_to(:access_transcript, pbcore_orr_transcript)
+      end
+
+      it 'access_transcript returns false for an Indexing transcript without public access' do
+        expect(ability).to_not be_able_to(:access_transcript, pbcore_indexing_transcript)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@afred - for AAPB transcript access we were pushing users through the same ability access method as playing video, but this was causing an issue as it was requiring the ORR rules of use check which wasn't getting handled correctly. i broke transcripts out in to their own ability check and reviewed the logic with @sroosa. any chance you could review today? thanks!

* Was using play ability, but it incorrectly required Rules of Use check
* Reduced ability check to only what is required