### PR TITLE
Adds exhibits/_sidebar_nav

### DIFF
--- a/app/views/exhibits/_sidebar_nav.html.erb
+++ b/app/views/exhibits/_sidebar_nav.html.erb
@@ -1,0 +1,26 @@
+<div class="panel panel-primary">
+  <% if title.present? %>
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= title %></h3>
+    </div>
+  <% end %>
+  <div class="panel-body">
+    <% if links.present? %>
+      <ul class="nav navbar-nav">
+        <% links.each do |name,link,subs=nil| %>
+          <li>
+            <%= link ? link_to(name, link, class: current_page(link)) : content_tag('a', name) %>
+            <%# <a> in either case for consistent style. %>
+          </li>
+          <% if subs %><%# This could be recursive... %>
+            <ul>
+              <% subs.each do |name,link| %>
+                <li>&bull; <%= link_to(name, link) %></li>
+              <% end %>
+            </ul>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/exhibits/show.html.erb
+++ b/app/views/exhibits/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :sidebar do %>
 
-  <%= render partial: 'shared/sidebar_nav',
+  <%= render partial: 'sidebar_nav',
              locals: {
                 title: 'Sections',
                 links: (@exhibit.children.empty? ? @exhibit.ancestors.first.children : @exhibit.children).sort_by(&:head_html).map { |child| [child.title, "/exhibits/#{child.path}"] }
@@ -15,7 +15,7 @@
     </div>
   </div>
 
-  <%= render(partial: 'shared/sidebar_nav',
+  <%= render(partial: 'sidebar_nav',
              locals: {
                 title: 'Resources',
                 links: @exhibit.resources


### PR DESCRIPTION
Section titles weren't displaying in Exhibits and, while I didn't track down the cause, I think that might have happened when we updated how we were displaying the About pages since they were using a shared template. Broke out the Exhibits in to their own sidebar template so that the section titles would display.  