### PR TITLE
Completes new title logic

### DIFF
--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -29,8 +29,8 @@ describe 'API' do
       expect(page).to have_text('my_callback({ "responseHeader"')
       expect(page).to have_text('"rows": "0"')
       expect(page).to have_text('"year:1988 AND iowa": 1')
-      expect(page).to have_text('"numFound": 38')
-      expect(page).to have_text('"1974", 3, "1987", 2, "1958", 1, "1961", 1, "1981", 1, "1983", 1, "1988", 1, "1990", 1, "1992", 1, "2000", 1, "2003", 1')
+      expect(page).to have_text('"numFound": 41')
+      expect(page).to have_text('"1974", 3, "2007", 3, "1987", 2, "1958", 1, "1961", 1, "1981", 1, "1983", 1, "1988", 1, "1990", 1, "1992", 1, "2000", 1, "2003", 1, "2006", 1')
     end
 
     it 'searches documents / json, not jsonp' do

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -116,13 +116,13 @@ describe 'Catalog' do
 
       describe 'facets' do
         assertions = [
-          ['media_type', 1, 'Sound', 10],
+          ['media_type', 1, 'Sound', 13],
           ['genres', 2, 'Interview', 5],
           ['topics', 1, 'Music', 3],
           ['asset_type', 1, 'Segment', 8],
           ['organizations', 41, 'WGBH+(MA)', 6], # tag ex and states mean lots of facet values.
           ['year', 1, '2000', 1],
-          ['access_types', 3, PBCore::ALL_ACCESS, 38]
+          ['access_types', 3, PBCore::ALL_ACCESS, 41]
         ]
         it 'has them all' do
           visit "/catalog?f[access_types][]=#{PBCore::ALL_ACCESS}"
@@ -166,9 +166,9 @@ describe 'Catalog' do
         describe 'URL support' do
           # OR is supported on all facets, even if not in the UI.
           assertions = [
-            ['media_type', 'Sound', 10],
-            ['media_type', 'Sound+OR+Moving+Image', 33],
-            ['media_type', 'Moving+Image+OR+Sound', 33],
+            ['media_type', 'Sound', 13],
+            ['media_type', 'Sound+OR+Moving+Image', 36],
+            ['media_type', 'Moving+Image+OR+Sound', 36],
             ['media_type', 'Moving+Image', 23]
           ]
           assertions.each do |facet, value, value_count|
@@ -189,7 +189,7 @@ describe 'Catalog' do
           expect(page).to have_text('You searched for: Access online')
 
           click_link('All Records')
-          expect_count(38)
+          expect_count(41)
           expect(page).to have_text('You searched for: Access all')
 
           click_link('KQED (CA)')
@@ -294,6 +294,7 @@ describe 'Catalog' do
         describe 'sorting, title edge cases' do
           url = "/catalog?f[access_types][]=#{PBCore::ALL_ACCESS}&sort=title+asc&per_page=50"
           it 'works' do
+            # rubocop:disable LineLength
             visit url
             expect(page.status_code).to eq(200)
             expect(
@@ -336,6 +337,7 @@ describe 'Catalog' do
                 ['Program: The Sorting Test: 1', 'Organization: WUSF', 'Media Type: other', 'Access: '],
                 ['Program: # "SORTING" Test: 2', 'Organization: Detroit Public Televi', 'Media Type: Moving Image', 'Access: '],
                 ['Program: A Sorting Test: 100', 'Organization: WNYC', 'Media Type: Moving Image', 'Access: '],
+                ['Title: This Title is Alterna', 'Copyright Date: 2006-10-23', 'Organization: WERU Community Radio', 'Media Type: Sound', 'Access: '],
                 ['Episode: Touchstone 108', 'Organization: Iowa Public Televisio', 'Media Type: Moving Image', 'Access: '],
                 ['Program: Unknown', 'Organization: WIAA', 'Media Type: Sound', 'Access: '],
                 ['Program: Winston Churchill Obi', 'Broadcast: 1958-00-00', 'Organization: Library of Congress,', 'Media Type: Moving Image', 'Access: '],
@@ -343,10 +345,13 @@ describe 'Catalog' do
                 ['Program: World Cafe', 'Segment: Larry Kane On John Le', 'Organization: WXPN', 'Media Type: Sound', 'Access: '],
                 ['Program: World Cafe', 'Segment: 1997-01-20 Sat/Mon', 'Segment: Martin Luther King, J', 'Organization: WXPN', 'Media Type: Sound', 'Access: '],
                 ['Collection: WQXR', 'Series: This is My Music', 'Episode: Judd Hirsch', 'Organization: WNYC', 'Media Type: Sound', 'Access: '],
+                ['Series: Writers Forum II', 'Episode Number: 43', 'Episode Number: 25', 'Episode: Writers Writing Again', 'Episode: Readers Reading Again', 'Copyright Date: 2007-10-15', 'Organization: WERU Community Radio', 'Media Type: Sound', 'Access: '],
                 ['Series: Writers Forum', 'Program: WRF-09/13/07', 'Copyright Date: 2007-09-13', 'Organization: WERU Community Radio', 'Media Type: Sound', 'Access: '],
+                ['Series: Writers Forum II', 'Series: Readers Forum', 'Episode Number: 42', 'Episode Number: 24', 'Episode: Writers Writing', 'Episode: Readers Reading', 'Copyright Date: 2007-10-13', 'Organization: WERU Community Radio', 'Media Type: Sound', 'Access: '],
                 ['Program: 15th Anniversary Show', 'Created: 1981-12-05', 'Organization: Arkansas Educational', 'Media Type: Moving Image', 'Access: Accessible on locatio']
               ].map { |x| x.join('; ') }.join("\n"))
             expect_fuzzy_xml
+            # rubocop:enable LineLength
           end
         end
       end

--- a/spec/fixtures/pbcore/clean-alternative-title.xml
+++ b/spec/fixtures/pbcore/clean-alternative-title.xml
@@ -1,0 +1,31 @@
+<pbcoreDescriptionDocument xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd' xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+  <!-- Root attributes are screwy in AMS export. -->
+  <pbcoreAssetDate dateType="Copyright">2006-10-23</pbcoreAssetDate>
+  <pbcoreIdentifier source='WERU Prog List'>WRF031</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/xxx-zxcvbnmq</pbcoreIdentifier>
+  <pbcoreTitle titleType='Alternative'>This Title is Alternative</pbcoreTitle>
+  <pbcoreDescription descriptionType='Description'>Writers Forum with readers.</pbcoreDescription>
+  <pbcoreCoverage>
+    <coverage>mock value which should be preserved</coverage>
+    <coverageType>Spatial</coverageType>
+  </pbcoreCoverage>
+  <pbcoreCoverage>
+    <coverage>mock value which should be preserved</coverage>
+    <coverageType>Temporal</coverageType>
+  </pbcoreCoverage>
+  <pbcoreRightsSummary>
+    <rightsSummary>There should be only one.</rightsSummary>
+  </pbcoreRightsSummary>
+  <pbcoreRightsSummary>  </pbcoreRightsSummary>
+  <pbcoreInstantiation>
+    <instantiationIdentifier source='WERU Prog List'>WRF031</instantiationIdentifier>
+    <instantiationIdentifier source='duplicate not to be removed'>Writers Forum</instantiationIdentifier>
+    <instantiationPhysical>CD</instantiationPhysical>
+    <instantiationLocation>WERU Archives - CD Shelves</instantiationLocation>
+    <instantiationMediaType>Sound</instantiationMediaType>
+    <instantiationGenerations>Original</instantiationGenerations>
+    <instantiationDuration>00:49:49</instantiationDuration>
+  </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType='last_modified'>2018-06-06 01:50:55</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='organization'>WERU-FM (WERU Community Radio)</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-multiple-episode-numbers-one-series.xml
+++ b/spec/fixtures/pbcore/clean-multiple-episode-numbers-one-series.xml
@@ -1,0 +1,35 @@
+<pbcoreDescriptionDocument xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd' xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+  <!-- Root attributes are screwy in AMS export. -->
+  <pbcoreAssetDate dateType="Copyright">2007-10-15</pbcoreAssetDate>
+  <pbcoreIdentifier source='WERU Prog List'>WRF030</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/xxx-zxcvbnma</pbcoreIdentifier>
+  <pbcoreTitle titleType='Series'>Writers Forum II</pbcoreTitle>
+  <pbcoreTitle titleType='Episode'>Writers Writing Again</pbcoreTitle>
+  <pbcoreTitle titleType='Episode'>Readers Reading Again</pbcoreTitle>
+  <pbcoreTitle titleType='Episode Number'>43</pbcoreTitle>
+  <pbcoreTitle titleType='Episode Number'>25</pbcoreTitle>
+  <pbcoreDescription descriptionType='Description'>Writers Forum with readers.</pbcoreDescription>
+  <pbcoreCoverage>
+    <coverage>mock value which should be preserved</coverage>
+    <coverageType>Spatial</coverageType>
+  </pbcoreCoverage>
+  <pbcoreCoverage>
+    <coverage>mock value which should be preserved</coverage>
+    <coverageType>Temporal</coverageType>
+  </pbcoreCoverage>
+  <pbcoreRightsSummary>
+    <rightsSummary>There should be only one.</rightsSummary>
+  </pbcoreRightsSummary>
+  <pbcoreRightsSummary>  </pbcoreRightsSummary>
+  <pbcoreInstantiation>
+    <instantiationIdentifier source='WERU Prog List'>WRF028</instantiationIdentifier>
+    <instantiationIdentifier source='duplicate not to be removed'>Writers Forum</instantiationIdentifier>
+    <instantiationPhysical>CD</instantiationPhysical>
+    <instantiationLocation>WERU Archives - CD Shelves</instantiationLocation>
+    <instantiationMediaType>Sound</instantiationMediaType>
+    <instantiationGenerations>Original</instantiationGenerations>
+    <instantiationDuration>00:59:49</instantiationDuration>
+  </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType='last_modified'>2013-06-06 01:50:55</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='organization'>WERU-FM (WERU Community Radio)</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/fixtures/pbcore/clean-multiple-series-with-episode-titles.xml
+++ b/spec/fixtures/pbcore/clean-multiple-series-with-episode-titles.xml
@@ -1,0 +1,36 @@
+<pbcoreDescriptionDocument xsi:schemaLocation='http://www.pbcore.org/PBCore/PBCoreNamespace.html http://www.pbcore.org/xsd/pbcore-2.0.xsd' xmlns='http://www.pbcore.org/PBCore/PBCoreNamespace.html' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+  <!-- Root attributes are screwy in AMS export. -->
+  <pbcoreAssetDate dateType="Copyright">2007-10-13</pbcoreAssetDate>
+  <pbcoreIdentifier source='WERU Prog List'>WRF029</pbcoreIdentifier>
+  <pbcoreIdentifier source='http://americanarchiveinventory.org'>cpb-aacip/xxx-zxcvbnml</pbcoreIdentifier>
+  <pbcoreTitle titleType='Series'>Writers Forum II</pbcoreTitle>
+  <pbcoreTitle titleType='Series'>Readers Forum</pbcoreTitle>
+  <pbcoreTitle titleType='Episode'>Writers Writing</pbcoreTitle>
+  <pbcoreTitle titleType='Episode'>Readers Reading</pbcoreTitle>
+  <pbcoreTitle titleType='Episode Number'>42</pbcoreTitle>
+  <pbcoreTitle titleType='Episode Number'>24</pbcoreTitle>
+  <pbcoreDescription descriptionType='Description'>Writers Forum with readers.</pbcoreDescription>
+  <pbcoreCoverage>
+    <coverage>mock value which should be preserved</coverage>
+    <coverageType>Spatial</coverageType>
+  </pbcoreCoverage>
+  <pbcoreCoverage>
+    <coverage>mock value which should be preserved</coverage>
+    <coverageType>Temporal</coverageType>
+  </pbcoreCoverage>
+  <pbcoreRightsSummary>
+    <rightsSummary>There should be only one.</rightsSummary>
+  </pbcoreRightsSummary>
+  <pbcoreRightsSummary>  </pbcoreRightsSummary>
+  <pbcoreInstantiation>
+    <instantiationIdentifier source='WERU Prog List'>WRF028</instantiationIdentifier>
+    <instantiationIdentifier source='duplicate not to be removed'>Writers Forum</instantiationIdentifier>
+    <instantiationPhysical>CD</instantiationPhysical>
+    <instantiationLocation>WERU Archives - CD Shelves</instantiationLocation>
+    <instantiationMediaType>Sound</instantiationMediaType>
+    <instantiationGenerations>Original</instantiationGenerations>
+    <instantiationDuration>00:58:49</instantiationDuration>
+  </pbcoreInstantiation>
+  <pbcoreAnnotation annotationType='last_modified'>2013-06-03 01:50:55</pbcoreAnnotation>
+  <pbcoreAnnotation annotationType='organization'>WERU-FM (WERU Community Radio)</pbcoreAnnotation>
+</pbcoreDescriptionDocument>

--- a/spec/models/pb_core_spec.rb
+++ b/spec/models/pb_core_spec.rb
@@ -14,6 +14,9 @@ describe 'Validated and plain PBCore' do
   let(:playlist_1) { File.read('spec/fixtures/pbcore/clean-playlist-1.xml') }
   let(:playlist_2) { File.read('spec/fixtures/pbcore/clean-playlist-2.xml') }
   let(:playlist_3) { File.read('spec/fixtures/pbcore/clean-playlist-3.xml') }
+  let(:pbc_multiple_series_with_episodes) { File.read('spec/fixtures/pbcore/clean-multiple-series-with-episode-titles.xml') }
+  let(:pbc_multiple_episodes_one_series) { File.read('spec/fixtures/pbcore/clean-multiple-episode-numbers-one-series.xml') }
+  let(:pbc_alternative_title) { File.read('spec/fixtures/pbcore/clean-alternative-title.xml') }
 
   describe ValidatedPBCore do
     describe 'valid docs' do
@@ -353,6 +356,20 @@ describe 'Validated and plain PBCore' do
         }
 
         expect(expected_attrs).to eq(attrs)
+      end
+    end
+
+    describe '.build_display_title' do
+      it 'uses only episode titles if there are more than one series title' do
+        expect(PBCore.new(pbc_multiple_series_with_episodes).title).to eq('Writers Writing; Readers Reading')
+      end
+
+      it 'uses only the series and episode titles if there are multiple episode numbers and only one series title' do
+        expect(PBCore.new(pbc_multiple_episodes_one_series).title).to eq('Writers Forum II; Writers Writing Again; Readers Reading Again')
+      end
+
+      it 'uses Alternative title if no other titles are present' do
+        expect(PBCore.new(pbc_alternative_title).title).to eq('This Title is Alternative')
       end
     end
   end

--- a/spec/scripts/pb_core_ingester_spec.rb
+++ b/spec/scripts/pb_core_ingester_spec.rb
@@ -49,7 +49,7 @@ describe PBCoreIngester do
     Dir[glob].each do |fixture_path|
       expect { @ingester.ingest(path: fixture_path) }.not_to raise_error
     end
-    expect_results(38)
+    expect_results(41)
   end
 
   def expect_results(count)


### PR DESCRIPTION
Per the ticket, this PR should apply the title logic expressed below:

"If a record has more than 1 series title, however many episode numbers, and at least one episode title - only use episode titles

If a record has an alternative title, and other titles - don't include the alternative title

If the record has multiple episode numbers, only 1 series title, and however many episode titles - only use the series title and episode title(s)

After these exceptions, keep the logic the same as it currently is."