### PR TITLE
Removes Play and Pause

### DIFF
--- a/app/assets/javascripts/player.js
+++ b/app/assets/javascripts/player.js
@@ -89,9 +89,7 @@ $(function(){
     // If timecode included in URL, play to pass thumbnail,
     // then pause at that timecode.
     if (url_hash) {
-        $player[0].play();
-        $player[0].currentTime = url_hash[1];
-        $player[0].pause();
+      $player[0].currentTime = url_hash[1];
     }
 
     // New for AAPB.


### PR DESCRIPTION
In order to force the video to display paused at the point included in the "#at_[number]_s" playback to a specific timecode we would play the video to get past the poster image and then pause the video at the timecode. Browser autoplay policies changed which broke our JS when it tried to play and then immediately pause. 

https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

This PR removes that from the JS and, per a short conversation with @sroosa, we're just going to let the poster image display.

Closes #1518 