### PR TITLE
1157 no stems

### DIFF
--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -23,7 +23,7 @@ class AdvancedController < ApplicationController
         "+titles:\"#{params[:title]}\"",
 
       !params[:exact].empty? &&
-        fieldnames.map.with_index {|fieldname, i| %(#{fieldname}:+"#{params[:exact]}"#{i != (fieldnames.count-1) ? ' OR ' : nil})}.join,
+        fieldnames.map.with_index {|fieldname, i| CGI.escape(%(#{fieldname}:+'#{params[:exact]}'#{i != (fieldnames.count-1) ? ' OR ' : nil}))}.join,
 
       !params[:any].empty? &&
         self.class.prefix(params[:any], '', ' OR '),

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -1,22 +1,24 @@
 require 'cgi'
 
 class AdvancedController < ApplicationController
-  def create
+  def index
+    @hidden_constraints = hidden_constraints
+  end
 
+  def create
     if params[:exact].empty?
       qoo = "#{query}"
     else
       # separate exact clause from rest of query
       qoo = "#{exactquery} #{query}"
     end
-    redirect_to "/catalog?q=#{CGI.escape(qoo)}"
+    redirect_to "/catalog?q=#{CGI.escape(qoo)}#{pass_constraints}"
   end
 
   def exactquery
     # mandatory OR query for each unstemmed field
     fieldnames = ['captions_unstemmed','text_unstemmed','titles_unstemmed','contribs_unstemmed','title_unstemmed','contributing_organizations_unstemmed','producing_organizations_unstemmed','genres_unstemmed','topics_unstemmed']
-    eq=fieldnames.map.with_index {|fieldname, i| %(#{fieldname}:"#{params[:exact]}"#{i != (fieldnames.count-1) ? ' OR ' : nil})}.join
-    %(+(#{eq}))
+    %(+(#{fieldnames.map {|fieldname| %(#{fieldname}:"#{params[:exact]}")}.join(' OR ')}))
   end
 
   def query
@@ -39,4 +41,16 @@ class AdvancedController < ApplicationController
   def self.prefix(terms, prefix, joint = ' ')
     terms.split(/\s+/).map { |term| "#{prefix}#{term}" }.join(joint)
   end
+
+  private
+
+  def hidden_constraints
+    params[:f]
+  end
+
+  def pass_constraints
+    # TODO: whitelist other parameters that we want to carry through advanced search to cat controller
+    params[:f].map {|k,v| %(&f[#{k}][]=#{v})}.join if params[:f]
+  end
+
 end

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -6,19 +6,26 @@ class AdvancedController < ApplicationController
   end
 
   def create
-    if params[:exact].empty?
-      qoo = "#{query}"
-    else
+    if params[:exact].present?
       # separate exact clause from rest of query
       qoo = "#{exactquery} #{query}"
     end
-    redirect_to "/catalog?q=#{CGI.escape(qoo)}#{pass_constraints}"
+    redirect_to "/catalog?q=#{CGI.escape(qoo || query)}#{pass_constraints}"
   end
 
   def exactquery
     # mandatory OR query for each unstemmed field
-    fieldnames = ['captions_unstemmed','text_unstemmed','titles_unstemmed','contribs_unstemmed','title_unstemmed','contributing_organizations_unstemmed','producing_organizations_unstemmed','genres_unstemmed','topics_unstemmed']
-    %(+(#{fieldnames.map {|fieldname| %(#{fieldname}:"#{params[:exact]}")}.join(' OR ')}))
+    fieldnames = %w(captions_unstemmed
+                    text_unstemmed
+                    titles_unstemmed
+                    contribs_unstemmed
+                    title_unstemmed
+                    contributing_organizations_unstemmed
+                    producing_organizations_unstemmed
+                    genres_unstemmed
+                    topics_unstemmed
+                  )
+    %(+(#{fieldnames.map { |fieldname| %(#{fieldname}:"#{params[:exact]}") }.join(' OR ')}))
   end
 
   def query
@@ -50,7 +57,6 @@ class AdvancedController < ApplicationController
 
   def pass_constraints
     # TODO: whitelist other parameters that we want to carry through advanced search to cat controller
-    params[:f].map {|k,v| %(&f[#{k}][]=#{v})}.join if params[:f]
+    params[:f].map { |k, v| %(&f[#{k}][]=#{v}) }.join if params[:f]
   end
-
 end

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -6,16 +6,17 @@ class AdvancedController < ApplicationController
     if params[:exact].empty?
       qoo = "#{query}"
     else
-      qoo = "#{exactquery}"
+      # separate exact clause from rest of query
+      qoo = "#{exactquery} #{query}"
     end
-    # qoo = "q=#{CGI.escape(query)}"
-    # qoo = %(q=+title_unstemmed:"racing")
-    redirect_to "/catalog?q=#{qoo}"
+    redirect_to "/catalog?q=#{CGI.escape(qoo)}"
   end
 
   def exactquery
+    # mandatory OR query for each unstemmed field
     fieldnames = ['captions_unstemmed','text_unstemmed','titles_unstemmed','contribs_unstemmed','title_unstemmed','contributing_organizations_unstemmed','producing_organizations_unstemmed','genres_unstemmed','topics_unstemmed']
-    fieldnames.map.with_index {|fieldname, i| %(+#{fieldname}:"#{params[:exact]}"#{i != (fieldnames.count-1) ? ' OR ' : nil})}.join
+    eq=fieldnames.map.with_index {|fieldname, i| %(#{fieldname}:"#{params[:exact]}"#{i != (fieldnames.count-1) ? ' OR ' : nil})}.join
+    %(+(#{eq}))
   end
 
   def query

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -7,17 +7,15 @@ class AdvancedController < ApplicationController
     # else
     #   ""
     # end
-    qoo = if !params[:exact].empty?
-      "q=" + CGI.escape(%(captions_unstemmed:+"#{params[:exact]}" OR text_unstemmed:+"#{params[:exact]}" OR titles_unstemmed:+"#{params[:exact]}" OR contribs_unstemmed:+"#{params[:exact]}" OR title_unstemmed:+"#{params[:exact]}" OR contributing_organizations_unstemmed:+"#{params[:exact]}" OR producing_organizations_unstemmed:+"#{params[:exact]}" OR genres_unstemmed:+"#{params[:exact]}" OR topics_unstemmed:+"#{params[:exact]}"))
-    else
-      "q=#{CGI.escape(query)}"
-    end
-
+    # qoo = "q=#{CGI.escape(query)}"
+    qoo = "q=#{query}"
     redirect_to "/catalog?#{qoo}"
   end
 
   def query
-    [
+    fieldnames = ['captions_unstemmed','text_unstemmed','titles_unstemmed','contribs_unstemmed','title_unstemmed','contributing_organizations_unstemmed','producing_organizations_unstemmed','genres_unstemmed','topics_unstemmed']
+
+    qooqoo = [
       !params[:all].empty? &&
         self.class.prefix(params[:all], '+'),
 
@@ -25,7 +23,7 @@ class AdvancedController < ApplicationController
         "+titles:\"#{params[:title]}\"",
 
       !params[:exact].empty? &&
-        "+\"#{params[:exact]}\"",
+        fieldnames.map.with_index {|fieldname, i| %(#{fieldname}:+"#{params[:exact]}"#{i != (fieldnames.count-1) ? ' OR ' : nil})}.join,
 
       !params[:any].empty? &&
         self.class.prefix(params[:any], '', ' OR '),
@@ -34,6 +32,8 @@ class AdvancedController < ApplicationController
         self.class.prefix(params[:none], '-')
 
     ].select { |clause| clause }.join(' ')
+
+    %((#{qooqoo}))
   end
 
   def self.prefix(terms, prefix, joint = ' ')

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -2,7 +2,18 @@ require 'cgi'
 
 class AdvancedController < ApplicationController
   def create
-    redirect_to "/catalog?q=#{CGI.escape(query)}"
+    # fqoo = if !params[:exact].empty?
+    #   # "&fq=" + CGI.escape(%((captions_unstemmed:+"#{params[:exact]}" OR text_unstemmed:+"#{params[:exact]}" OR titles_unstemmed:+"#{params[:exact]}" OR contribs_unstemmed:+"#{params[:exact]}" OR title_unstemmed:+"#{params[:exact]}" OR contributing_organizations_unstemmed:+"#{params[:exact]}" OR producing_organizations_unstemmed:+"#{params[:exact]}" OR genres_unstemmed:+"#{params[:exact]}" OR topics_unstemmed:+"#{params[:exact]}")))
+    # else
+    #   ""
+    # end
+    qoo = if !params[:exact].empty?
+      "q=" + CGI.escape(%(captions_unstemmed:+"#{params[:exact]}" OR text_unstemmed:+"#{params[:exact]}" OR titles_unstemmed:+"#{params[:exact]}" OR contribs_unstemmed:+"#{params[:exact]}" OR title_unstemmed:+"#{params[:exact]}" OR contributing_organizations_unstemmed:+"#{params[:exact]}" OR producing_organizations_unstemmed:+"#{params[:exact]}" OR genres_unstemmed:+"#{params[:exact]}" OR topics_unstemmed:+"#{params[:exact]}"))
+    else
+      "q=#{CGI.escape(query)}"
+    end
+
+    redirect_to "/catalog?#{qoo}"
   end
 
   def query

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -188,18 +188,18 @@ class CatalogController < ApplicationController
 
     # Cleans up user query for manipulation of caption text in the view.
     @query_for_captions = clean_query_for_snippet(params[:q]) if params[:q]
-
-    if !params[:f] || !params[:f][:access_types]
-      base_query = params.except(:action, :controller).to_query
-      access = if current_user.onsite?
-                 PBCore::DIGITIZED_ACCESS
-               else
-                 PBCore::PUBLIC_ACCESS
-               end
-      redirect_to "/catalog?#{base_query}&f[access_types][]=#{access}"
-    else
+    #
+    # if !params[:f] || !params[:f][:access_types]
+    #   base_query = params.except(:action, :controller).to_query
+    #   access = if current_user.onsite?
+    #              PBCore::DIGITIZED_ACCESS
+    #            else
+    #              PBCore::PUBLIC_ACCESS
+    #            end
+    #   redirect_to "/catalog?#{base_query}&f[access_types][]=#{access}"
+    # else
       super
-    end
+    # end
 
     # mark results for captions and transcripts
     matched_in_text_field = @document_list.first.response['highlighting'] if @document_list.try(:first)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -29,7 +29,6 @@ class CatalogController < ApplicationController
       # enable hit highlighting for 'text' field for transcript/caption hit compilation
       hl: true,
       :"hl.fl" => 'text'
-
     }
 
     # solr path which will be added to solr base url before the other solr params.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -188,18 +188,18 @@ class CatalogController < ApplicationController
 
     # Cleans up user query for manipulation of caption text in the view.
     @query_for_captions = clean_query_for_snippet(params[:q]) if params[:q]
-    #
-    # if !params[:f] || !params[:f][:access_types]
-    #   base_query = params.except(:action, :controller).to_query
-    #   access = if current_user.onsite?
-    #              PBCore::DIGITIZED_ACCESS
-    #            else
-    #              PBCore::PUBLIC_ACCESS
-    #            end
-    #   redirect_to "/catalog?#{base_query}&f[access_types][]=#{access}"
-    # else
+
+    if !params[:f] || !params[:f][:access_types]
+      base_query = params.except(:action, :controller).to_query
+      access = if current_user.onsite?
+                 PBCore::DIGITIZED_ACCESS
+               else
+                 PBCore::PUBLIC_ACCESS
+               end
+      redirect_to "/catalog?#{base_query}&f[access_types][]=#{access}"
+    else
       super
-    # end
+    end
 
     # mark results for captions and transcripts
     matched_in_text_field = @document_list.first.response['highlighting'] if @document_list.try(:first)

--- a/app/models/caption_file.rb
+++ b/app/models/caption_file.rb
@@ -1,6 +1,5 @@
 require 'open-uri'
 require_relative '../../lib/caption_converter'
-include SnippetHelper
 
 class CaptionFile
   URL_BASE = 'https://s3.amazonaws.com/americanarchive.org/captions'.freeze

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -16,6 +16,6 @@
   <% end %>
 
   <div class="form-group">
-    <input type="submit" class="btn btn-primary" value="Search"/>
+    <input id="advanced-search" type="submit" class="btn btn-primary" value="Search"/>
   </div>
 <% end %>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -15,6 +15,20 @@
     </div>
   <% end %>
 
+  <% if @hidden_constraints %>
+    <% @hidden_constraints.each do |param_name, param_val| %>
+      <% if param_val.is_a? Array %>
+        <% param_val.each do |p| %>
+          <%=  %(<input type="hidden" name="f[#{param_name}][]" value="#{p}">).html_safe %>
+        <% end %>
+      <% else %>
+        <input type="hidden" name="f[<%= param_name %>]" value="<%= param_val %>">
+      <% end %>
+
+    <% end %>
+
+  <% end %>
+
   <div class="form-group">
     <input id="advanced-search" type="submit" class="btn btn-primary" value="Search"/>
   </div>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -4,6 +4,10 @@
       <%=link_to "Clear Search", start_over_path, :class => "catalog_startOverLink btn btn-sm btn-text", :id=>"startOverLink" %>
     </div>
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
-    <%= render_constraints(params) %>
+
+    <% #TODO: maybe less crazy? %>
+    <% c=render_constraints(params) %>
+    <% z= "!+" + c.scan(/_unstemmed:&quot(.*?&quot)/).flatten.first.chomp(%(&quot)) %>
+    <%= c.include?('_unstemmed') ? c.gsub(/\+\(.*?\)/, z).delete(';').html_safe : c.html_safe %>
   </div>
 <% end %>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -5,9 +5,11 @@
     </div>
     <span class="constraints-label"><%= t('blacklight.search.filters.title') %></span>
 
-    <% #TODO: maybe less crazy? %>
     <% c=render_constraints(params) %>
-    <% z= "!+" + c.scan(/_unstemmed:&quot(.*?&quot)/).flatten.first.chomp(%(&quot)) %>
-    <%= c.include?('_unstemmed') ? c.gsub(/\+\(.*?\)/, z).delete(';').html_safe : c.html_safe %>
+    <% if c.include?('_unstemmed') %>
+      <%= z= "!!" + c.scan(/_unstemmed:&quot(.*?&quot)/).flatten.first.chomp(%(&quot)); c.gsub(/\+\(.*?\)/, z).delete(';').html_safe %>
+    <% else %>
+      <%= c.html_safe %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/catalog/_search_form_big.html.erb
+++ b/app/views/catalog/_search_form_big.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag search_action_url, :method => :get, :class => 'search-query-form clearfix' do %>
-<%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= render_hash_as_hidden_fields(params_for_search().except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group input-group-lg search-group" role="search">
     <!-- Selector removed: they can use advanced search. -->
     <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
+ contributor license agreements. See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
+ the License. You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,604 +29,563 @@
  http://wiki.apache.org/solr/SchemaXml
 
  PERFORMANCE NOTE: this schema includes many optional features and should not
- be used for benchmarking.  To improve performance one could
-  - set stored="false" for all fields possible (esp large fields) when you
-    only need to search on the field but don't need to return the original
-    value.
-  - set indexed="false" if you don't need to search on the field, but only
-    return the field as a result of searching on other indexed fields.
-  - remove all unneeded copyField statements
-  - for best index size and searching performance, set "index" to false
-    for all general text fields, use copyField to copy them to the
-    catchall "text" field, and use that for searching.
-  - For maximum indexing performance, use the StreamingUpdateSolrServer
-    java client.
-  - Remember to run the JVM in server mode, and use a higher logging level
-    that avoids logging every request
+ be used for benchmarking. To improve performance one could
+ - set stored="false" for all fields possible (esp large fields) when you
+  only need to search on the field but don't need to return the original
+  value.
+ - set indexed="false" if you don't need to search on the field, but only
+  return the field as a result of searching on other indexed fields.
+ - remove all unneeded copyField statements
+ - for best index size and searching performance, set "index" to false
+  for all general text fields, use copyField to copy them to the
+  catchall "text" field, and use that for searching.
+ - For maximum indexing performance, use the StreamingUpdateSolrServer
+  java client.
+ - Remember to run the JVM in server mode, and use a higher logging level
+  that avoids logging every request
 -->
 
 <schema name="Blacklight Demo Index" version="1.5">
-  <!-- attribute "name" is the name of this schema and is only used for display purposes.
-       Applications should change this to reflect the nature of the search collection.
-       version="1.4" is Solr's version number for the schema syntax and semantics.  It should
-       not normally be changed by applications.
-       1.0: multiValued attribute did not exist, all fields are multiValued by nature
-       1.1: multiValued attribute introduced, false by default
-       1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
-       1.3: removed optional field compress feature
-       1.4: default auto-phrase (QueryParser feature) to off
-     -->
+ <!-- attribute "name" is the name of this schema and is only used for display purposes.
+    Applications should change this to reflect the nature of the search collection.
+    version="1.4" is Solr's version number for the schema syntax and semantics. It should
+    not normally be changed by applications.
+    1.0: multiValued attribute did not exist, all fields are multiValued by nature
+    1.1: multiValued attribute introduced, false by default
+    1.2: omitTermFreqAndPositions attribute introduced, true by default except for text fields.
+    1.3: removed optional field compress feature
+    1.4: default auto-phrase (QueryParser feature) to off
+   -->
 
-  <types>
-    <!-- field type definitions. The "name" attribute is
-       just a label to be used by field definitions.  The "class"
-       attribute and any other attributes determine the real
-       behavior of the fieldType.
-         Class names starting with "solr" refer to java classes in the
-       org.apache.solr.analysis package.
-    -->
+ <types>
+  <!-- field type definitions. The "name" attribute is
+    just a label to be used by field definitions. The "class"
+    attribute and any other attributes determine the real
+    behavior of the fieldType.
+     Class names starting with "solr" refer to java classes in the
+    org.apache.solr.analysis package.
+  -->
 
-    <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+  <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
+  <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
 
-    <!-- boolean type: "true" or "false" -->
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
-    <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
-    <fieldtype name="binary" class="solr.BinaryField"/>
+  <!-- boolean type: "true" or "false" -->
+  <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+  <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
+  <fieldtype name="binary" class="solr.BinaryField"/>
 
-    <!-- The optional sortMissingLast and sortMissingFirst attributes are
-         currently supported on types that are sorted internally as strings
-         and on numeric types.
-	       This includes "string","boolean", and, as of 3.5 (and 4.x),
-	       int, float, long, date, double, including the "Trie" variants.
-       - If sortMissingLast="true", then a sort on this field will cause documents
-         without the field to come after documents with the field,
-         regardless of the requested sort order (asc or desc).
-       - If sortMissingFirst="true", then a sort on this field will cause documents
-         without the field to come before documents with the field,
-         regardless of the requested sort order.
-       - If sortMissingLast="false" and sortMissingFirst="false" (the default),
-         then default lucene sorting will be used which places docs without the
-         field first in an ascending sort and last in a descending sort.
-    -->
+  <!-- The optional sortMissingLast and sortMissingFirst attributes are
+     currently supported on types that are sorted internally as strings
+     and on numeric types.
+	    This includes "string","boolean", and, as of 3.5 (and 4.x),
+	    int, float, long, date, double, including the "Trie" variants.
+    - If sortMissingLast="true", then a sort on this field will cause documents
+     without the field to come after documents with the field,
+     regardless of the requested sort order (asc or desc).
+    - If sortMissingFirst="true", then a sort on this field will cause documents
+     without the field to come before documents with the field,
+     regardless of the requested sort order.
+    - If sortMissingLast="false" and sortMissingFirst="false" (the default),
+     then default lucene sorting will be used which places docs without the
+     field first in an ascending sort and last in a descending sort.
+  -->
 
-    <!--
-      Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
-    -->
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <!--
+   Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
+  -->
+  <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
 
-    <!--
-     Numeric field types that index each value at various levels of precision
-     to accelerate range queries when the number of values between the range
-     endpoints is large. See the javadoc for NumericRangeQuery for internal
-     implementation details.
+  <!--
+   Numeric field types that index each value at various levels of precision
+   to accelerate range queries when the number of values between the range
+   endpoints is large. See the javadoc for NumericRangeQuery for internal
+   implementation details.
 
-     Smaller precisionStep values (specified in bits) will lead to more tokens
-     indexed per value, slightly larger index size, and faster range queries.
-     A precisionStep of 0 disables indexing at different precision levels.
-    -->
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+   Smaller precisionStep values (specified in bits) will lead to more tokens
+   indexed per value, slightly larger index size, and faster range queries.
+   A precisionStep of 0 disables indexing at different precision levels.
+  -->
+  <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+  <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
 
-    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
-         is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime
-         The trailing "Z" designates UTC time and is mandatory.
-         Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
-         All other components are mandatory.
+  <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
+     is a more restricted form of the canonical representation of dateTime
+     http://www.w3.org/TR/xmlschema-2/#dateTime
+     The trailing "Z" designates UTC time and is mandatory.
+     Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
+     All other components are mandatory.
 
-         Expressions can also be used to denote calculations that should be
-         performed relative to "NOW" to determine the value, ie...
+     Expressions can also be used to denote calculations that should be
+     performed relative to "NOW" to determine the value, ie...
 
-               NOW/HOUR
-                  ... Round to the start of the current hour
-               NOW-1DAY
-                  ... Exactly 1 day prior to now
-               NOW/DAY+6MONTHS+3DAYS
-                  ... 6 months and 3 days in the future from the start of
-                      the current day
+        NOW/HOUR
+         ... Round to the start of the current hour
+        NOW-1DAY
+         ... Exactly 1 day prior to now
+        NOW/DAY+6MONTHS+3DAYS
+         ... 6 months and 3 days in the future from the start of
+           the current day
 
-         Consult the DateField javadocs for more information.
+     Consult the DateField javadocs for more information.
 
-         Note: For faster range queries, consider the tdate type
-      -->
-    <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
+     Note: For faster range queries, consider the tdate type
+   -->
+  <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
 
-    <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+  <!-- A Trie based date field for faster date range queries and date faceting. -->
+  <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
 
 
-    <!-- The "RandomSortField" is not used to store or search any
-         data.  You can declare fields of this type it in your schema
-         to generate pseudo-random orderings of your docs for sorting
-         purposes.  The ordering is generated based on the field name
-         and the version of the index, As long as the index version
-         remains unchanged, and the same field name is reused,
-         the ordering of the docs will be consistent.
-         If you want different psuedo-random orderings of documents,
-         for the same version of the index, use a dynamicField and
-         change the name
-     -->
-    <fieldType name="random" class="solr.RandomSortField" indexed="true" />
+  <!-- The "RandomSortField" is not used to store or search any
+     data. You can declare fields of this type it in your schema
+     to generate pseudo-random orderings of your docs for sorting
+     purposes. The ordering is generated based on the field name
+     and the version of the index, As long as the index version
+     remains unchanged, and the same field name is reused,
+     the ordering of the docs will be consistent.
+     If you want different psuedo-random orderings of documents,
+     for the same version of the index, use a dynamicField and
+     change the name
+   -->
+  <fieldType name="random" class="solr.RandomSortField" indexed="true" />
 
-    <!-- solr.TextField allows the specification of custom text analyzers
-         specified as a tokenizer and a list of token filters. Different
-         analyzers may be specified for indexing and querying.
+  <!-- solr.TextField allows the specification of custom text analyzers
+     specified as a tokenizer and a list of token filters. Different
+     analyzers may be specified for indexing and querying.
 
-         The optional positionIncrementGap puts space between multiple fields of
-         this type on the same document, with the purpose of preventing false phrase
-         matching across fields.
+     The optional positionIncrementGap puts space between multiple fields of
+     this type on the same document, with the purpose of preventing false phrase
+     matching across fields.
 
-         For more info on customizing your analyzer chain, please see
-         http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
-     -->
-     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
-       <analyzer>
-         <tokenizer class="solr.StandardTokenizerFactory"/>
-         <filter class="solr.ICUFoldingFilterFactory" />
-         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-         <filter class="solr.SnowballPorterFilterFactory" language="English" />
-       </analyzer>
-     </fieldType>
+     For more info on customizing your analyzer chain, please see
+     http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
+   -->
+   <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+    <analyzer>
+     <tokenizer class="solr.StandardTokenizerFactory"/>
+     <filter class="solr.ICUFoldingFilterFactory" />
+     <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+     <filter class="solr.SnowballPorterFilterFactory" language="English" />
+    </analyzer>
+   </fieldType>
 
-    <!-- One can also specify an existing Analyzer class that has a
-         default constructor via the class attribute on the analyzer element
-    <fieldType name="text_greek" class="solr.TextField">
-      <analyzer class="org.apache.lucene.analysis.el.GreekAnalyzer"/>
-    </fieldType>
-    -->
+  <!-- One can also specify an existing Analyzer class that has a
+     default constructor via the class attribute on the analyzer element
+  <fieldType name="text_greek" class="solr.TextField">
+   <analyzer class="org.apache.lucene.analysis.el.GreekAnalyzer"/>
+  </fieldType>
+  -->
 
-    <!-- A text field that only splits on whitespace for exact matching of words -->
-    <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      </analyzer>
-    </fieldType>
+  <!-- A text field that only splits on whitespace for exact matching of words -->
+  <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
+   <analyzer>
+    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <!-- A general text field that has reasonable, generic
-         cross-language defaults: it tokenizes with StandardTokenizer,
+  <!-- A general text field that has reasonable, generic
+     cross-language defaults: it tokenizes with StandardTokenizer,
 	 removes stop words from case-insensitive "stopwords.txt"
-	 (empty by default), and down cases.  At query time only, it
+	 (empty by default), and down cases. At query time only, it
 	 also applies synonyms. -->
-    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
+  <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+   <analyzer type="index">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+    <!-- in this example, we will only use synonyms at query time
+    <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+    -->
+    <filter class="solr.LowerCaseFilterFactory"/>
+   </analyzer>
+   <analyzer type="query">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+    <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+    <filter class="solr.LowerCaseFilterFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <!-- A text field with defaults appropriate for English: it
-         tokenizes with StandardTokenizer, removes English stop words
-         (stopwords_en.txt), down cases, protects words from protwords.txt, and
-         finally applies Porter's stemming.  The query time analyzer
-         also applies synonyms from synonyms.txt. -->
-    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
-        -->
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="stopwords_en.txt"
-                enablePositionIncrements="true"
-                />
-        <filter class="solr.LowerCaseFilterFactory"/>
+  <!-- A text field with defaults appropriate for English: it
+     tokenizes with StandardTokenizer, removes English stop words
+     (stopwords_en.txt), down cases, protects words from protwords.txt, and
+     finally applies Porter's stemming. The query time analyzer
+     also applies synonyms from synonyms.txt. -->
+  <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+   <analyzer type="index">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <!-- in this example, we will only use synonyms at query time
+    <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+    -->
+    <!-- Case insensitive stop word removal.
+     add enablePositionIncrements=true in both the index and query
+     analyzers to leave a 'gap' for more accurate phrase queries.
+    -->
+    <filter class="solr.StopFilterFactory"
+        ignoreCase="true"
+        words="stopwords_en.txt"
+        enablePositionIncrements="true"
+        />
+    <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+    <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
 	<!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+    <filter class="solr.EnglishMinimalStemFilterFactory"/>
 	-->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="stopwords_en.txt"
-                enablePositionIncrements="true"
-                />
-        <filter class="solr.LowerCaseFilterFactory"/>
+    <filter class="solr.PorterStemFilterFactory"/>
+   </analyzer>
+   <analyzer type="query">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+    <filter class="solr.StopFilterFactory"
+        ignoreCase="true"
+        words="stopwords_en.txt"
+        enablePositionIncrements="true"
+        />
+    <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+    <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
 	<!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+    <filter class="solr.EnglishMinimalStemFilterFactory"/>
 	-->
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
+    <filter class="solr.PorterStemFilterFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <!-- A text field with defaults appropriate for English, plus
+  <!-- A text field with defaults appropriate for English, plus
 	 aggressive word-splitting and autophrase features enabled.
 	 This field is just like text_en, except it adds
 	 WordDelimiterFilter to enable splitting and matching of
 	 words on case-change, alpha numeric boundaries, and
-	 non-alphanumeric chars.  This means certain compound word
+	 non-alphanumeric chars. This means certain compound word
 	 cases will work, for example query "wi fi" will match
-	 document "WiFi" or "wi-fi".  However, other cases will still
+	 document "WiFi" or "wi-fi". However, other cases will still
 	 not match, for example if the query is "wifi" and the
 	 document is "wi fi" or if the query is "wi-fi" and the
 	 document is "wifi".
-        -->
-    <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
-        <!-- Case insensitive stop word removal.
-          add enablePositionIncrements=true in both the index and query
-          analyzers to leave a 'gap' for more accurate phrase queries.
-        -->
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="stopwords_en.txt"
-                enablePositionIncrements="true"
-                />
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory"
-                ignoreCase="true"
-                words="stopwords_en.txt"
-                enablePositionIncrements="true"
-                />
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.PorterStemFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Less flexible matching, but less false matches.  Probably not ideal for product names,
-         but may be good for SKUs.  Can insert dashes in the wrong place and still match. -->
-    <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
-        <filter class="solr.EnglishMinimalStemFilterFactory"/>
-        <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterFilter in conjuncton with stemming. -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- Just like text_general except it reverses the characters of
-	 each token, to enable more efficient leading wildcard queries. -->
-    <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
-           maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
-        <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
-        <filter class="solr.StandardFilterFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-      </analyzer>
-    </fieldType>
-
-    <!-- charFilter + WhitespaceTokenizer  -->
-    <!--
-    <fieldType name="text_char_norm" class="solr.TextField" positionIncrementGap="100" >
-      <analyzer>
-        <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-      </analyzer>
-    </fieldType>
     -->
-
-    <!-- This is an example of using the KeywordTokenizer along
-         With various TokenFilterFactories to produce a sortable field
-         that does not include some properties of the source text
-      -->
-    <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
-      <analyzer>
-        <!-- KeywordTokenizer does no actual tokenizing, so the entire
-             input string is preserved as a single token
-          -->
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <!-- The LowerCase TokenFilter does what you expect, which can be
-             when you want your sorting to be case insensitive
-          -->
-        <filter class="solr.LowerCaseFilterFactory" />
-        <!-- The TrimFilter removes any leading or trailing whitespace -->
-        <filter class="solr.TrimFilterFactory" />
-        <!-- The PatternReplaceFilter gives you the flexibility to use
-             Java Regular expression to replace any sequence of characters
-             matching a pattern with an arbitrary replacement string,
-             which may include back references to portions of the original
-             string matched by the pattern.
-
-             See the Java Regular Expression documentation for more
-             information on pattern and replacement string syntax.
-
-             http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/package-summary.html
-          -->
-        <filter class="solr.PatternReplaceFilterFactory"
-                pattern="([^a-z])" replacement="" replace="all"
+  <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+   <analyzer type="index">
+    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    <!-- in this example, we will only use synonyms at query time
+    <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
+    -->
+    <!-- Case insensitive stop word removal.
+     add enablePositionIncrements=true in both the index and query
+     analyzers to leave a 'gap' for more accurate phrase queries.
+    -->
+    <filter class="solr.StopFilterFactory"
+        ignoreCase="true"
+        words="stopwords_en.txt"
+        enablePositionIncrements="true"
         />
-      </analyzer>
-    </fieldType>
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+    <filter class="solr.LowerCaseFilterFactory"/>
+    <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+    <filter class="solr.PorterStemFilterFactory"/>
+   </analyzer>
+   <analyzer type="query">
+    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt" enablePositionIncrements="true"
+        />
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+    <filter class="solr.LowerCaseFilterFactory"/>
+    <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+    <filter class="solr.PorterStemFilterFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
-      <analyzer>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
-      </analyzer>
-    </fieldtype>
+  <!-- Less flexible matching, but less false matches. Probably not ideal for product names,
+     but may be good for SKUs. Can insert dashes in the wrong place and still match. -->
+  <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+   <analyzer>
+    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+    <filter class="solr.LowerCaseFilterFactory"/>
+    <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
+    <filter class="solr.EnglishMinimalStemFilterFactory"/>
+    <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
+       possible with WordDelimiterFilter in conjuncton with stemming. -->
+    <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <fieldtype name="payloads" stored="false" indexed="true" class="solr.TextField" >
-      <analyzer>
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!--
-        The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
-        a token of "foo|1.4"  would be indexed as "foo" with a payload of 1.4f
-        Attributes of the DelimitedPayloadTokenFilterFactory :
-         "delimiter" - a one character delimiter. Default is | (pipe)
-	 "encoder" - how to encode the following value into a playload
-	    float -> org.apache.lucene.analysis.payloads.FloatEncoder,
-	    integer -> o.a.l.a.p.IntegerEncoder
-	    identity -> o.a.l.a.p.IdentityEncoder
-            Fully Qualified class name implementing PayloadEncoder, Encoder must have a no arg constructor.
-         -->
-        <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
-      </analyzer>
-    </fieldtype>
+  <!-- Just like text_general except it reverses the characters of
+	 each token, to enable more efficient leading wildcard queries. -->
+  <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
+   <analyzer type="index">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+    <filter class="solr.LowerCaseFilterFactory"/>
+    <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true" maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33"/>
+   </analyzer>
+   <analyzer type="query">
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true" />
+    <filter class="solr.LowerCaseFilterFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <!-- lowercases the entire field value, keeping it as a single token.  -->
-    <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
-      </analyzer>
-    </fieldType>
+  <fieldType name="textSpell" class="solr.TextField" positionIncrementGap="100" >
+   <analyzer>
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
+    <filter class="solr.StandardFilterFactory"/>
+    <filter class="solr.LowerCaseFilterFactory"/>
+    <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+   </analyzer>
+  </fieldType>
 
-    <fieldType name="text_path" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.PathHierarchyTokenizerFactory"/>
-      </analyzer>
-    </fieldType>
+  <!-- charFilter + WhitespaceTokenizer -->
+  <!--
+  <fieldType name="text_char_norm" class="solr.TextField" positionIncrementGap="100" >
+   <analyzer>
+    <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ISOLatin1Accent.txt"/>
+    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+   </analyzer>
+  </fieldType>
+  -->
 
-    <!-- since fields of this type are by default not stored or indexed,
-         any data added to them will be ignored outright.  -->
-    <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
-
-    <!-- This point type indexes the coordinates as separate fields (subFields)
-      If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if
-      subFieldSuffix is defined, that is used to create the subFields.
-      Example: if subFieldType="double", then the coordinates would be
-        indexed in fields myloc_0___double,myloc_1___double.
-      Example: if subFieldSuffix="_d" then the coordinates would be indexed
-        in fields myloc_0_d,myloc_1_d
-      The subFields are an implementation detail of the fieldType, and end
-      users normally should not need to know about them.
-     -->
-    <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-
-    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-
-   <!--
-    A Geohash is a compact representation of a latitude longitude pair in a single field.
-    See http://wiki.apache.org/solr/SpatialSearch
+  <!-- This is an example of using the KeywordTokenizer along
+     With various TokenFilterFactories to produce a sortable field
+     that does not include some properties of the source text
    -->
-    <fieldtype name="geohash" class="solr.GeoHashField"/>
+  <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+   <analyzer>
+    <!-- KeywordTokenizer does no actual tokenizing, so the entire
+       input string is preserved as a single token
+     -->
+    <tokenizer class="solr.KeywordTokenizerFactory"/>
+    <!-- The LowerCase TokenFilter does what you expect, which can be
+       when you want your sorting to be case insensitive
+     -->
+    <filter class="solr.LowerCaseFilterFactory" />
+    <!-- The TrimFilter removes any leading or trailing whitespace -->
+    <filter class="solr.TrimFilterFactory" />
+    <!-- The PatternReplaceFilter gives you the flexibility to use
+       Java Regular expression to replace any sequence of characters
+       matching a pattern with an arbitrary replacement string,
+       which may include back references to portions of the original
+       string matched by the pattern.
 
-    <fieldType name="sort" class="solr.TextField">
-        <analyzer>
-            <!-- One token -->
-            <tokenizer class="solr.KeywordTokenizerFactory"/>
-            <filter class="solr.ASCIIFoldingFilterFactory"/>
-            <filter class="solr.LowerCaseFilterFactory"/>
-            <filter class="solr.TrimFilterFactory"/>
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="[^a-z0-9\s]+" replacement="" replace="all"/>
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="^\s*(a |an |the )?" replacement="" replace="all"/>
-            <!-- Pad with "z" so numbers sort last -->
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="(\d+)" replacement="zzzz$1" replace="all"/>
-            <!-- Zero pad to mask lexicographic sort behavior. -->
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="(\d+)" replacement="00000$1" replace="all"/>
-            <filter class="solr.PatternReplaceFilterFactory"
-                    pattern="0*([0-9]{6,})" replacement="$1" replace="all"/>
-        </analyzer>
-    </fieldType>
+       See the Java Regular Expression documentation for more
+       information on pattern and replacement string syntax.
 
-    <!-- unstemmed fieldtype -->
-    <fieldtype name="textNoStem" class="solr.TextField" positionIncrementGap="100">
-      <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory" />
-        <filter class="schema.UnicodeNormalizationFilterFactory" version="icu4j" composed="false" remove_diacritics="true" remove_modifiers="true" fold="true" />
+       http://java.sun.com/j2se/1.5.0/docs/api/java/util/regex/package-summary.html
+     -->
+    <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z])" replacement="" replace="all" />
+   </analyzer>
+  </fieldType>
 
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
-        <filter class="solr.LowerCaseFilterFactory" />
-        <!-- dont double include identical terms -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
-      </analyzer>
-      <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory" />
-        <filter class="schema.UnicodeNormalizationFilterFactory" version="icu4j" composed="false" remove_diacritics="true" remove_modifiers="true" fold="true" />
+  <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
+   <analyzer>
+    <tokenizer class="solr.StandardTokenizerFactory"/>
+    <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
+   </analyzer>
+  </fieldtype>
 
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
-        <filter class="solr.LowerCaseFilterFactory" />
-        <!-- dont double include identical terms -->
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
-      </analyzer>
-    </fieldtype>
+  <fieldtype name="payloads" stored="false" indexed="true" class="solr.TextField" >
+   <analyzer>
+    <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+    <!--
+    The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
+    a token of "foo|1.4" would be indexed as "foo" with a payload of 1.4f
+    Attributes of the DelimitedPayloadTokenFilterFactory :
+     "delimiter" - a one character delimiter. Default is | (pipe)
+	 "encoder" - how to encode the following value into a playload
+	  float -> org.apache.lucene.analysis.payloads.FloatEncoder,
+	  integer -> o.a.l.a.p.IntegerEncoder
+	  identity -> o.a.l.a.p.IdentityEncoder
+      Fully Qualified class name implementing PayloadEncoder, Encoder must have a no arg constructor.
+     -->
+    <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
+   </analyzer>
+  </fieldtype>
+
+  <!-- lowercases the entire field value, keeping it as a single token. -->
+  <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
+   <analyzer>
+    <tokenizer class="solr.KeywordTokenizerFactory"/>
+    <filter class="solr.LowerCaseFilterFactory" />
+   </analyzer>
+  </fieldType>
+
+  <fieldType name="text_path" class="solr.TextField" positionIncrementGap="100">
+   <analyzer>
+    <tokenizer class="solr.PathHierarchyTokenizerFactory"/>
+   </analyzer>
+  </fieldType>
+
+  <!-- since fields of this type are by default not stored or indexed,
+     any data added to them will be ignored outright. -->
+  <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
+
+  <!-- This point type indexes the coordinates as separate fields (subFields)
+   If subFieldType is defined, it references a type, and a dynamic field
+   definition is created matching *___<typename>. Alternately, if
+   subFieldSuffix is defined, that is used to create the subFields.
+   Example: if subFieldType="double", then the coordinates would be
+    indexed in fields myloc_0___double,myloc_1___double.
+   Example: if subFieldSuffix="_d" then the coordinates would be indexed
+    in fields myloc_0_d,myloc_1_d
+   The subFields are an implementation detail of the fieldType, and end
+   users normally should not need to know about them.
+   -->
+  <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+
+  <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
+  <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+
+  <!--
+  A Geohash is a compact representation of a latitude longitude pair in a single field.
+  See http://wiki.apache.org/solr/SpatialSearch
+  -->
+  <fieldtype name="geohash" class="solr.GeoHashField"/>
+
+  <fieldType name="sort" class="solr.TextField">
+    <analyzer>
+      <!-- One token -->
+      <tokenizer class="solr.KeywordTokenizerFactory"/>
+      <filter class="solr.ASCIIFoldingFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.PatternReplaceFilterFactory" pattern="[^a-z0-9\s]+" replacement="" replace="all"/>
+      <filter class="solr.PatternReplaceFilterFactory" pattern="^\s*(a |an |the )?" replacement="" replace="all"/>
+      <!-- Pad with "z" so numbers sort last -->
+      <filter class="solr.PatternReplaceFilterFactory" pattern="(\d+)" replacement="zzzz$1" replace="all"/>
+      <!-- Zero pad to mask lexicographic sort behavior. -->
+      <filter class="solr.PatternReplaceFilterFactory" pattern="(\d+)" replacement="00000$1" replace="all"/>
+      <filter class="solr.PatternReplaceFilterFactory" pattern="0*([0-9]{6,})" replacement="$1" replace="all"/>
+    </analyzer>
+  </fieldType>
+
+  <!-- unstemmed fieldtype -->
+  <fieldtype name="textNoStem" class="solr.TextField" positionIncrementGap="100">
+   <analyzer type="index">
+    <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
+    <filter class="solr.LowerCaseFilterFactory" />
+    <!-- dont double include identical terms -->
+    <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+   </analyzer>
+   <analyzer type="query">
+    <tokenizer class="solr.WhitespaceTokenizerFactory" />
+
+    <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
+    <filter class="solr.LowerCaseFilterFactory" />
+    <!-- dont double include identical terms -->
+    <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+   </analyzer>
+  </fieldtype>
 
  </types>
 
 
  <fields>
-   <!-- Valid attributes for fields:
-     name: mandatory - the name for the field
-     type: mandatory - the name of a previously defined type from the
-       <types> section
-     indexed: true if this field should be indexed (searchable or sortable)
-     stored: true if this field should be retrievable
-     multiValued: true if this field may contain multiple values per document
-     omitNorms: (expert) set to true to omit the norms associated with
-       this field (this disables length normalization and index-time
-       boosting for the field, and saves some memory).  Only full-text
-       fields or fields that need an index-time boost need norms.
-     termVectors: [false] set to true to store the term vector for a
-       given field.
-       When using MoreLikeThis, fields used for similarity should be
-       stored for best performance.
-     termPositions: Store position information with the term vector.
-       This will increase storage costs.
-     termOffsets: Store offset information with the term vector. This
-       will increase storage costs.
-     default: a value that should be used if no value is specified
-       when adding a document.
-   -->
+  <!-- Valid attributes for fields:
+   name: mandatory - the name for the field
+   type: mandatory - the name of a previously defined type from the
+    <types> section
+   indexed: true if this field should be indexed (searchable or sortable)
+   stored: true if this field should be retrievable
+   multiValued: true if this field may contain multiple values per document
+   omitNorms: (expert) set to true to omit the norms associated with
+    this field (this disables length normalization and index-time
+    boosting for the field, and saves some memory). Only full-text
+    fields or fields that need an index-time boost need norms.
+   termVectors: [false] set to true to store the term vector for a
+    given field.
+    When using MoreLikeThis, fields used for similarity should be
+    stored for best performance.
+   termPositions: Store position information with the term vector.
+    This will increase storage costs.
+   termOffsets: Store offset information with the term vector. This
+    will increase storage costs.
+   default: a value that should be used if no value is specified
+    when adding a document.
+  -->
 
 
-   <field name="id"
-          type="string" indexed="true" stored="true" required="true" />
-   <field name="timestamp"
-          type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+  <field name="id" type="string" indexed="true" stored="true" required="true" />
+  <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
-   <field name="xml"
-          type="string" indexed="false" stored="true" multiValued="false"/>
-   <field name="captions"
-          type="string" indexed="true" stored="false" multiValued="false"/>
+  <field name="xml" type="string" indexed="false" stored="true" multiValued="false"/>
+  <field name="captions" type="string" indexed="true" stored="false" multiValued="false"/>
 
-   <field name="exhibits"
-          type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="exhibits" type="string" indexed="true" stored="true" multiValued="true"/>
 
-  <field name="special_collection"
-          type="string" indexed="true" stored="true" multiValued="false"/>
+ <field name="special_collection" type="string" indexed="true" stored="true" multiValued="false"/>
 
-   <!-- Nothing below needs to be stored. -->
+  <!-- Nothing below needs to be stored. -->
 
-   <!-- default, catch all search field -->
-   <field name="text"
-          type="text" indexed="true" stored="false" multiValued="true"/>
-   <!-- Available as search constraints -->
-   <field name="titles"
-          type="text" indexed="true" stored="false" multiValued="true"/>
-   <field name="contribs"
-          type="text" indexed="true" stored="false" multiValued="true"/>
+  <!-- default, catch all search field -->
+  <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+  <!-- Available as search constraints -->
+  <field name="titles" type="text" indexed="true" stored="false" multiValued="true"/>
+  <field name="contribs" type="text" indexed="true" stored="false" multiValued="true"/>
 
-   <!-- sorting --><!-- TODO: stored=true only for debugging. -->
-   <field name="title"
-          type="sort" indexed="true" stored="true" multiValued="false"/>
+  <!-- sorting --><!-- TODO: stored=true only for debugging. -->
+  <field name="title" type="sort" indexed="true" stored="true" multiValued="false"/>
 
-   <!-- sorting and facet -->
-   <field name="year"
-          type="string" indexed="true" stored="false" multiValued="false"/>
+  <!-- sorting and facet -->
+  <field name="year" type="string" indexed="true" stored="false" multiValued="false"/>
 
-   <!-- facet -->
-   <field name="media_type"
-          type="string" indexed="true" stored="false" multiValued="false"/>
-   <field name="asset_type"
-          type="string" indexed="true" stored="false" multiValued="false"/>
-   <field name="contributing_organizations"
-          type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="producing_organizations"
-          type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="genres"
-          type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="topics"
-          type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="access_types"
-          type="string" indexed="true" stored="false" multiValued="true"/>
-   <field name="states"
-          type="string" indexed="true" stored="false" multiValued="true"/>
+  <!-- facet -->
+  <field name="media_type" type="string" indexed="true" stored="false" multiValued="false"/>
+  <field name="asset_type" type="string" indexed="true" stored="false" multiValued="false"/>
+  <field name="contributing_organizations" type="string" indexed="true" stored="false" multiValued="true"/>
+  <field name="producing_organizations" type="string" indexed="true" stored="false" multiValued="true"/>
+  <field name="genres" type="string" indexed="true" stored="false" multiValued="true"/>
+  <field name="topics" type="string" indexed="true" stored="false" multiValued="true"/>
+  <field name="access_types" type="string" indexed="true" stored="false" multiValued="true"/>
+  <field name="states" type="string" indexed="true" stored="false" multiValued="true"/>
 
-   <dynamicField name="*_titles"
-          type="string" indexed="true" stored="false" multiValued="true"/>
+  <dynamicField name="*_titles" type="string" indexed="true" stored="false" multiValued="true"/>
 
-   <!-- playlist support -->
-   <field name="playlist_group"
-          type="string" indexed="true" stored="true" multiValued="false"/>
-   <field name="playlist_order"
-          type="string" indexed="true" stored="true" multiValued="false"/>
+  <!-- playlist support -->
+  <field name="playlist_group" type="string" indexed="true" stored="true" multiValued="false"/>
+  <field name="playlist_order" type="string" indexed="true" stored="true" multiValued="false"/>
 
 
-   <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
-   <!-- Not used by AAPB -->
-   <!--<field name="format" type="string" indexed="true" stored="true"/>-->
-   <field name="captions_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
-   <copyField source="captions" destination="captions_unstemmed" />
+  <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
+  <!-- Not used by AAPB -->
+  <!--<field name="format" type="string" indexed="true" stored="true"/>-->
 
-   <field name="text_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="text" destination="text_unstemmed" />
-
-   <field name="titles_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="titles" destination="titles_unstemmed" />
-
-   <field name="contribs_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="contribs" destination="contribs_unstemmed" />
-
-   <field name="title_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
-   <copyField source="title" destination="title_unstemmed" />
-
-   <field name="contributing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="contributing_organizations" destination="contributing_organizations_unstemmed" />
-
-   <field name="producing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="producing_organizations" destination="producing_organizations_unstemmed" />
-
-   <field name="genres_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="genres" destination="genres_unstemmed" />
-
-   <field name="topics_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <copyField source="topics" destination="topics_unstemmed" />
+  <field name="captions_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+  <field name="text_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+  <field name="titles_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+  <field name="contribs_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+  <field name="title_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+  <field name="contributing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+  <field name="producing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+  <field name="genres_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+  <field name="topics_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
 
 
+
+  <copyField source="captions" dest="captions_unstemmed" />
+  <copyField source="text" dest="text_unstemmed" />
+  <copyField source="titles" dest="titles_unstemmed" />
+  <copyField source="contribs" dest="contribs_unstemmed" />
+  <copyField source="title" dest="title_unstemmed" />
+  <copyField source="contributing_organizations" dest="contributing_organizations_unstemmed" />
+  <copyField source="producing_organizations" dest="producing_organizations_unstemmed" />
+  <copyField source="genres" dest="genres_unstemmed" />
+  <copyField source="topics" dest="topics_unstemmed" />
  </fields>
 
  <!-- Field to use to determine and enforce document uniqueness.
-      Unless this field is marked with required="false", it will be a required field
-   -->
+   Unless this field is marked with required="false", it will be a required field
+  -->
  <uniqueKey>id</uniqueKey>
 
  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
@@ -635,62 +594,62 @@
  <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
  <solrQueryParser defaultOperator="OR"/>
 
-  <!-- copyField commands copy one field to another at the time a document
-        is added to the index.  It's used either to index the same field differently,
-        or to add multiple fields to the same field for easier/faster searching.  -->
-   <!-- Copy Fields -->
+ <!-- copyField commands copy one field to another at the time a document
+    is added to the index. It's used either to index the same field differently,
+    or to add multiple fields to the same field for easier/faster searching. -->
+  <!-- Copy Fields -->
 
-   <!-- unstemmed fields -->
-   <!--
-   <copyField source="title_t" dest="title_unstem_search"/>
-   ...
-   -->
+  <!-- unstemmed fields -->
+  <!--
+  <copyField source="title_t" dest="title_unstem_search"/>
+  ...
+  -->
 
-   <!-- sort fields -->
-   <!--
-   <copyField source="pub_date" dest="pub_date_sort"/>
-   ...
-   -->
+  <!-- sort fields -->
+  <!--
+  <copyField source="pub_date" dest="pub_date_sort"/>
+  ...
+  -->
 
-   <!-- spellcheck fields -->
-   <!-- default spell check;  should match fields for default request handler -->
-   <!-- it won't work with a copy of a copy field -->
-   <!--
-   <copyField source="*_t" dest="spell"/>
-   <copyField source="*_facet" dest="spell"/>
-   ...
-   -->
-
-
-   <!-- OpenSearch query field should match request handler search fields -->
-   <!--
-   <copyField source="title_t" dest="opensearch_display"/>
-   ...
-   -->
+  <!-- spellcheck fields -->
+  <!-- default spell check; should match fields for default request handler -->
+  <!-- it won't work with a copy of a copy field -->
+  <!--
+  <copyField source="*_t" dest="spell"/>
+  <copyField source="*_facet" dest="spell"/>
+  ...
+  -->
 
 
-   <!-- Above, multiple source fields are copied to the [text] field.
-	  Another way to map multiple source fields to the same
-	  destination field is to use the dynamic field syntax.
-	  copyField also supports a maxChars to copy setting.  -->
+  <!-- OpenSearch query field should match request handler search fields -->
+  <!--
+  <copyField source="title_t" dest="opensearch_display"/>
+  ...
+  -->
 
-   <!--<copyField source="*_tesim" dest="text"/>-->
 
-   <!-- copy name to alphaNameSort, a field designed for sorting by name -->
-   <!-- <copyField source="name" dest="alphaNameSort"/> -->
+  <!-- Above, multiple source fields are copied to the [text] field.
+	 Another way to map multiple source fields to the same
+	 destination field is to use the dynamic field syntax.
+	 copyField also supports a maxChars to copy setting. -->
+
+  <!--<copyField source="*_tesim" dest="text"/>-->
+
+  <!-- copy name to alphaNameSort, a field designed for sorting by name -->
+  <!-- <copyField source="name" dest="alphaNameSort"/> -->
 
 
  <!-- Similarity is the scoring routine for each document vs. a query.
-      A custom similarity may be specified here, but the default is fine
-      for most applications.  -->
+   A custom similarity may be specified here, but the default is fine
+   for most applications. -->
  <!-- <similarity class="org.apache.lucene.search.DefaultSimilarity"/> -->
  <!-- ... OR ...
-      Specify a SimilarityFactory class name implementation
-      allowing parameters to be used.
+   Specify a SimilarityFactory class name implementation
+   allowing parameters to be used.
  -->
  <!--
  <similarity class="com.example.solr.CustomSimilarityFactory">
-   <str name="paramkey">param value</str>
+  <str name="paramkey">param value</str>
  </similarity>
  -->
 

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -594,33 +594,33 @@
    <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
    <!-- Not used by AAPB -->
    <!--<field name="format" type="string" indexed="true" stored="true"/>-->
-
-   <copyField source="captions" destination="captions_unstemmed" />
    <field name="captions_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+   <copyField source="captions" destination="captions_unstemmed" />
 
-   <copyField source="text" destination="text_unstemmed" />
    <field name="text_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-   <!-- Available as search constraints -->
-   <copyField source="titles" destination="titles_unstemmed" />
+   <copyField source="text" destination="text_unstemmed" />
+
    <field name="titles_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <copyField source="titles" destination="titles_unstemmed" />
 
-   <copyField source="contribs" destination="contribs_unstemmed" />
    <field name="contribs_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <copyField source="contribs" destination="contribs_unstemmed" />
 
-   <copyField source="title" destination="title_unstemmed" />
    <field name="title_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+   <copyField source="title" destination="title_unstemmed" />
 
-   <copyField source="contributing_organizations" destination="contributing_organizations_unstemmed" />
    <field name="contributing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <copyField source="contributing_organizations" destination="contributing_organizations_unstemmed" />
 
-   <copyField source="producing_organizations" destination="producing_organizations_unstemmed" />
    <field name="producing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <copyField source="producing_organizations" destination="producing_organizations_unstemmed" />
 
-   <copyField source="genres" destination="genres_unstemmed" />
    <field name="genres_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <copyField source="genres" destination="genres_unstemmed" />
 
-   <copyField source="topics" destination="topics_unstemmed" />
    <field name="topics_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <copyField source="topics" destination="topics_unstemmed" />
+
 
  </fields>
 

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -593,18 +593,8 @@
    <!-- Not used by AAPB -->
    <!--<field name="format" type="string" indexed="true" stored="true"/>-->
 
-   <copyField source="xml" destination="xml_unstemmed" />
-   <field name="xml_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
-
    <copyField source="captions" destination="captions_unstemmed" />
    <field name="captions_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
-
-   <!-- not sure what the content is -->
-   <copyField source="exhibits" destination="exhibits_unstemmed" />
-   <field name="exhibits_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-
-   <copyField source="special_collection" destination="special_collection_unstemmed" />
-   <field name="special_collection_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
 
    <copyField source="text" destination="text_unstemmed" />
    <field name="text_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -477,6 +477,29 @@
                     pattern="0*([0-9]{6,})" replacement="$1" replace="all"/>
         </analyzer>
     </fieldType>
+
+    <!-- unstemmed fieldtype -->
+    <fieldtype name="textNoStem" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="schema.UnicodeNormalizationFilterFactory" version="icu4j" composed="false" remove_diacritics="true" remove_modifiers="true" fold="true" />
+
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" />
+        <filter class="solr.LowerCaseFilterFactory" />
+        <!-- dont double include identical terms -->
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="schema.UnicodeNormalizationFilterFactory" version="icu4j" composed="false" remove_diacritics="true" remove_modifiers="true" fold="true" />
+
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" />
+        <filter class="solr.LowerCaseFilterFactory" />
+        <!-- dont double include identical terms -->
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+      </analyzer>
+    </fieldtype>
+
  </types>
 
 
@@ -569,6 +592,43 @@
    <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
    <!-- Not used by AAPB -->
    <!--<field name="format" type="string" indexed="true" stored="true"/>-->
+
+   <copyField source="xml" destination="xml_unstemmed" />
+   <field name="xml_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+
+   <copyField source="captions" destination="captions_unstemmed" />
+   <field name="captions_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+
+   <!-- not sure what the content is -->
+   <copyField source="exhibits" destination="exhibits_unstemmed" />
+   <field name="exhibits_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+
+   <copyField source="special_collection" destination="special_collection_unstemmed" />
+   <field name="special_collection_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+
+   <copyField source="text" destination="text_unstemmed" />
+   <field name="text_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+   <!-- Available as search constraints -->
+   <copyField source="titles" destination="titles_unstemmed" />
+   <field name="titles_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+
+   <copyField source="contribs" destination="contribs_unstemmed" />
+   <field name="contribs_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+
+   <copyField source="title" destination="title_unstemmed" />
+   <field name="title_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="false" />
+
+   <copyField source="contributing_organizations" destination="contributing_organizations_unstemmed" />
+   <field name="contributing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+
+   <copyField source="producing_organizations" destination="producing_organizations_unstemmed" />
+   <field name="producing_organizations_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+
+   <copyField source="genres" destination="genres_unstemmed" />
+   <field name="genres_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
+
+   <copyField source="topics" destination="topics_unstemmed" />
+   <field name="topics_unstemmed" type="textNoStem" indexed="true" stored="false" multiValued="true" />
 
  </fields>
 

--- a/solr_conf/schema.xml
+++ b/solr_conf/schema.xml
@@ -527,6 +527,7 @@
        when adding a document.
    -->
 
+
    <field name="id"
           type="string" indexed="true" stored="true" required="true" />
    <field name="timestamp"
@@ -588,6 +589,7 @@
           type="string" indexed="true" stored="true" multiValued="false"/>
    <field name="playlist_order"
           type="string" indexed="true" stored="true" multiValued="false"/>
+
 
    <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
    <!-- Not used by AAPB -->

--- a/spec/controllers/advanced_controller_spec.rb
+++ b/spec/controllers/advanced_controller_spec.rb
@@ -5,11 +5,11 @@ describe AdvancedController do
     assertions = [
       [{ all: 'all of these' }, '+all +of +these'],
       [{ title: 'some title' }, '+titles:"some title"'],
-      [{ exact: 'exactly these' }, '+(captions_unstemmed:"exactly these" OR text_unstemmed:"exactly these" OR titles_unstemmed:"exactly these" OR contribs_unstemmed:"exactly these" OR title_unstemmed:"exactly these" OR contributing_organizations_unstemmed:"exactly these" OR producing_organizations_unstemmed:"exactly these" OR genres_unstemmed:"exactly these" OR topics_unstemmed:"exactly these")'],
+      [{ exact: 'exactly these' }, '+(captions_unstemmed:"exactly these" OR text_unstemmed:"exactly these" OR titles_unstemmed:"exactly these" OR contribs_unstemmed:"exactly these" OR title_unstemmed:"exactly these" OR contributing_organizations_unstemmed:"exactly these" OR producing_organizations_unstemmed:"exactly these" OR genres_unstemmed:"exactly these" OR topics_unstemmed:"exactly these") '],
       [{ any: 'any of these' }, 'any OR of OR these'],
       [{ none: 'none of these' }, '-none -of -these'],
       [{ all: 'all', title: 'title', exact: 'exact', any: 'any', none: 'none' },
-       '+all +titles:"title" +"exact" any -none']
+       '+(captions_unstemmed:"exact" OR text_unstemmed:"exact" OR titles_unstemmed:"exact" OR contribs_unstemmed:"exact" OR title_unstemmed:"exact" OR contributing_organizations_unstemmed:"exact" OR producing_organizations_unstemmed:"exact" OR genres_unstemmed:"exact" OR topics_unstemmed:"exact") +all +titles:"title" any -none']
     ]
     assertions.each do |params, query|
       it "handles #{params}" do

--- a/spec/controllers/advanced_controller_spec.rb
+++ b/spec/controllers/advanced_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 describe AdvancedController do
   describe 'redirection' do
     assertions = [

--- a/spec/controllers/advanced_controller_spec.rb
+++ b/spec/controllers/advanced_controller_spec.rb
@@ -5,7 +5,7 @@ describe AdvancedController do
     assertions = [
       [{ all: 'all of these' }, '+all +of +these'],
       [{ title: 'some title' }, '+titles:"some title"'],
-      [{ exact: 'exactly these' }, '+"exactly these"'],
+      [{ exact: 'exactly these' }, '+(captions_unstemmed:"exactly these" OR text_unstemmed:"exactly these" OR titles_unstemmed:"exactly these" OR contribs_unstemmed:"exactly these" OR title_unstemmed:"exactly these" OR contributing_organizations_unstemmed:"exactly these" OR producing_organizations_unstemmed:"exactly these" OR genres_unstemmed:"exactly these" OR topics_unstemmed:"exactly these")'],
       [{ any: 'any of these' }, 'any OR of OR these'],
       [{ none: 'none of these' }, '-none -of -these'],
       [{ all: 'all', title: 'title', exact: 'exact', any: 'any', none: 'none' },

--- a/spec/controllers/advanced_controller_spec.rb
+++ b/spec/controllers/advanced_controller_spec.rb
@@ -5,11 +5,14 @@ describe AdvancedController do
     assertions = [
       [{ all: 'all of these' }, '+all +of +these'],
       [{ title: 'some title' }, '+titles:"some title"'],
+      # rubocop:disable LineLength
       [{ exact: 'exactly these' }, '+(captions_unstemmed:"exactly these" OR text_unstemmed:"exactly these" OR titles_unstemmed:"exactly these" OR contribs_unstemmed:"exactly these" OR title_unstemmed:"exactly these" OR contributing_organizations_unstemmed:"exactly these" OR producing_organizations_unstemmed:"exactly these" OR genres_unstemmed:"exactly these" OR topics_unstemmed:"exactly these") '],
+      # rubocop:enable LineLength
       [{ any: 'any of these' }, 'any OR of OR these'],
       [{ none: 'none of these' }, '-none -of -these'],
-      [{ all: 'all', title: 'title', exact: 'exact', any: 'any', none: 'none' },
-       '+(captions_unstemmed:"exact" OR text_unstemmed:"exact" OR titles_unstemmed:"exact" OR contribs_unstemmed:"exact" OR title_unstemmed:"exact" OR contributing_organizations_unstemmed:"exact" OR producing_organizations_unstemmed:"exact" OR genres_unstemmed:"exact" OR topics_unstemmed:"exact") +all +titles:"title" any -none']
+      # rubocop:disable LineLength
+      [{ all: 'all', title: 'title', exact: 'exact', any: 'any', none: 'none' }, '+(captions_unstemmed:"exact" OR text_unstemmed:"exact" OR titles_unstemmed:"exact" OR contribs_unstemmed:"exact" OR title_unstemmed:"exact" OR contributing_organizations_unstemmed:"exact" OR producing_organizations_unstemmed:"exact" OR genres_unstemmed:"exact" OR topics_unstemmed:"exact") +all +titles:"title" any -none']
+      # rubocop:enable LineLength
     ]
     assertions.each do |params, query|
       it "handles #{params}" do

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require_relative '../../lib/aapb'
+require_relative '../../scripts/lib/pb_core_ingester'
+
+describe "Advanced Search Integration" do
+  before(:all) do
+    PBCoreIngester.load_fixtures
+  end
+
+  before(:each) do
+    visit '/advanced'
+  end
+
+  it 'can do an exact search' do
+
+    fill_in('exact', with: 'Rez')
+    find('#advanced-search').click
+
+    require('pry');binding.pry
+    expect some shit
+  end
+
+  it 'can do a hybrid search' do
+
+  end
+
+  it 'can do an all these words search' do
+  end
+end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require_relative '../../lib/aapb'
 require_relative '../../scripts/lib/pb_core_ingester'
 
-describe "Advanced Search Integration" do
+describe 'Advanced Search Integration' do
   before(:all) do
     PBCoreIngester.load_fixtures
   end
@@ -12,13 +12,12 @@ describe "Advanced Search Integration" do
   end
 
   it 'matches entire phrase for exact search' do
-
     fill_in('exact', with: 'Win or lose')
     find('#advanced-search').click
-    expect(page).to have_text("Racing the Rez")
-    expect(page).to_not have_text("The Lost Year")
-    expect(page).to_not have_text("The Civil War; Interviews with Barbara Fields")
-    expect(page).to have_text("1 entry found")
+    expect(page).to have_text('Racing the Rez')
+    expect(page).to_not have_text('The Lost Year')
+    expect(page).to_not have_text('The Civil War; Interviews with Barbara Fields')
+    expect(page).to have_text('1 entry found')
   end
 
   it 'searches with a mix of exact and other search terms' do
@@ -28,9 +27,8 @@ describe "Advanced Search Integration" do
     fill_in('any', with: 'vision')
     fill_in('none', with: 'artichoke')
     find('#advanced-search').click
-    expect(page).to have_text("Racing the Rez")
+    expect(page).to have_text('Racing the Rez')
   end
-
 
   it 'enforces none of these words searches' do
     fill_in('all', with: 'rez')
@@ -38,7 +36,7 @@ describe "Advanced Search Integration" do
     fill_in('any', with: 'vision')
     fill_in('none', with: 'racing')
     find('#advanced-search').click
-    expect(page).to_not have_text("Racing the Rez")
-    expect(page).to have_text("No entries found")
+    expect(page).to_not have_text('Racing the Rez')
+    expect(page).to have_text('No entries found')
   end
 end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -8,20 +8,18 @@ describe "Advanced Search Integration" do
   end
 
   before(:each) do
-    visit '/advanced'
+    visit "/advanced?f[access_types][]=#{PBCore::ALL_ACCESS}"
   end
 
   it 'can do an exact search' do
 
     fill_in('exact', with: 'Rez')
     find('#advanced-search').click
-
-    require('pry');binding.pry
-    expect some shit
+    # records dont come up as they do when searching from client?
+    expect(page).to have_text("Racing the Rez")
   end
 
   it 'can do a hybrid search' do
-
   end
 
   it 'can do an all these words search' do

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -11,17 +11,34 @@ describe "Advanced Search Integration" do
     visit "/advanced?f[access_types][]=#{PBCore::ALL_ACCESS}"
   end
 
-  it 'can do an exact search' do
+  it 'matches entire phrase for exact search' do
 
-    fill_in('exact', with: 'Rez')
+    fill_in('exact', with: 'Win or lose')
     find('#advanced-search').click
-    # records dont come up as they do when searching from client?
+    expect(page).to have_text("Racing the Rez")
+    expect(page).to_not have_text("The Lost Year")
+    expect(page).to_not have_text("The Civil War; Interviews with Barbara Fields")
+    expect(page).to have_text("1 entry found")
+  end
+
+  it 'searches with a mix of exact and other search terms' do
+    fill_in('all', with: 'rez')
+    fill_in('title', with: 'racing')
+    fill_in('exact', with: 'runners')
+    fill_in('any', with: 'vision')
+    fill_in('none', with: 'artichoke')
+    find('#advanced-search').click
     expect(page).to have_text("Racing the Rez")
   end
 
-  it 'can do a hybrid search' do
-  end
 
-  it 'can do an all these words search' do
+  it 'enforces none of these words searches' do
+    fill_in('all', with: 'rez')
+    fill_in('exact', with: 'runners')
+    fill_in('any', with: 'vision')
+    fill_in('none', with: 'racing')
+    find('#advanced-search').click
+    expect(page).to_not have_text("Racing the Rez")
+    expect(page).to have_text("No entries found")
   end
 end

--- a/spec/features/advanced_search_spec.rb
+++ b/spec/features/advanced_search_spec.rb
@@ -30,7 +30,7 @@ describe 'Advanced Search Integration' do
     expect(page).to have_text('Racing the Rez')
   end
 
-  it 'enforces none of these words searches' do
+  it 'enforces "none of these words" searches' do
     fill_in('all', with: 'rez')
     fill_in('exact', with: 'runners')
     fill_in('any', with: 'vision')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 require_relative 'support/remote_ip_monkey_patch'
 


### PR DESCRIPTION

-Altered schema to add unstemmed fieldtype, with copyfields to fill in '_unstemmed' versions of all relevant (text content) fields
-When exact match field has input, requires an exact match in one of the new unstemmed field
-The other advanced search fields should work correctly alongside the exact match search.

This should require a reingest to get those farm-fresh _unstemmed fields populated.