### PR TITLE
Turbolynx Redux

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,9 @@
 
 // Play|Pause for Homepage Background Video
 //= stub background-video
+//= stub transcript
+//= stub mobile-transcript
+//= stub player
 
 // For blacklight_range_limit built-in JS, if you don't want it you don't need
 // this:

--- a/app/assets/javascripts/player.js
+++ b/app/assets/javascripts/player.js
@@ -57,18 +57,19 @@ $(document).on('turbolinks:load', function() {
     skipPlayer(true);
   });
 
-
   $player.on('timeupdate', function(){
       var current = $player[0].currentTime;
       var key = greatest_less_than_or_equal_to(current);
       var $line = lines[key];
       var class_name = 'current';
-      if (!$line.hasClass(class_name)) {
+      if ($line && !$line.hasClass(class_name)) {
           $transcript.contents().find('[data-timecodebegin]').removeClass(class_name);
           $line.addClass(class_name);
       };
       if (!is_user_scroll()) {
-          $('iframe').contents().scrollTop($line.position().top-30);
+          if($line){
+            $('iframe').contents().scrollTop($line.position().top-30);
+          }
           // "-30" to get the speaker's name at the top;
           // ... but when a single monologue is broken into
           // parts this doesn't look as good: we get a line
@@ -140,7 +141,11 @@ $(document).on('turbolinks:load', function() {
   var $divTranscript = $('div.transcript-div');
   var $divPlayer = $('div.player');
   var $divExhibitPromo = $('div.exhibit-promo');
-  var player = videojs('#player_media_html5_api');
+
+  if($('#player_media').length != 0){
+    var player = videojs('#player_media');
+  }
+
   var exhibit = $('#exhibit-banner');
   var search = $('div.transcript-search');
   var searchInput = $('.transcript-search-input')

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -1,11 +1,17 @@
 <% content_for :video do %>
   <link href="https://vjs.zencdn.net/7.2.3/video-js.css" rel="stylesheet">
-  <script src="https://vjs.zencdn.net/7.2.3/video.js" ></script>
+  <script data-turbolinks-tracks="false" src="https://vjs.zencdn.net/7.2.3/video.js" ></script>
   <!-- If you'd like to support IE8 (for Video.js versions prior to v7) -->
-  <script src="https://vjs.zencdn.net/ie8/ie8-version/videojs-ie8.min.js" ></script>
-  <%= javascript_include_tag 'transcript', 'data-turbolinks-track': 'false' %>
-  <%= javascript_include_tag 'mobile-transcript', 'data-turbolinks-track': 'false' %>
-  <%= javascript_include_tag 'player', 'data-turbolinks-track': 'false' %>
+  <script data-turbolinks-tracks="false" src="https://vjs.zencdn.net/ie8/ie8-version/videojs-ie8.min.js" ></script>
+  <%= javascript_include_tag 'transcript' %>
+  <%= javascript_include_tag 'mobile-transcript' %>
+  <%= javascript_include_tag 'player' %>
+<% end %>
+
+
+<% content_for :head do %>
+  <!-- without this, record page will fail to *initially* load/execute player.js -->
+  <meta name="turbolinks-visit-control" content="reload">
 <% end %>
 
 <!-- player or thumbnail or message -->
@@ -108,5 +114,3 @@
 <% @pbcore.reference_urls.each do |url| %>
   <%= link_to 'More information on this record is available.', url %>
 <% end %>
-
-<%= yield :video %>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -57,7 +57,7 @@
     </main>
 
     <%= render :partial => 'shared/footer' %>
-  </body>
 
-  <%= yield :video %>
+    <%= yield :video %>
+  </body>
 </html>


### PR DESCRIPTION
stub from app js
  so individual js files dont get included in applciation.js

include js files in assets rb
  so individual js files do get precompiled as separate file_present

javascript_include_tag (not script tag -> override_controller)
  dont need turbolinks-track-false (because of meta tag v)

meta reload tag
  prevents initial player.js screwup

env.rb
  assets.compile = false
  dont live compile assets.. for Performance!