### PR TITLE
1739 SpecialCollections Fixes

### DIFF
--- a/app/models/special_collection.rb
+++ b/app/models/special_collection.rb
@@ -86,4 +86,11 @@ class SpecialCollection < Cmless
         ]
       end
   end
+
+  def self.valid_collection?(collection_name)
+    SpecialCollection.find_by_path(collection_name)
+    true
+  rescue Cmless::Error
+    false
+  end
 end

--- a/app/views/catalog/_player.html.erb
+++ b/app/views/catalog/_player.html.erb
@@ -96,12 +96,14 @@
 <% end %>
 <% if @pbcore.special_collections %>
   <% @pbcore.special_collections.each do |collection| %>
-    <% coll = SpecialCollection.find_by_path(collection) %>
-    <% coll_caption = "This record is featured in “#{coll.title}.”" %>
-    <a href="/special_collections/<%= coll.path %>" class="btn-featured-record" title="<%= coll_caption %>" id="exhibit-banner">
-      <span class="glyphicon glyphicon-star"></span>
-      <strong><%= coll_caption %></strong>
-    </a>
+    <% if SpecialCollection.valid_collection?(collection) %>
+      <% coll = SpecialCollection.find_by_path(collection) %>
+      <% coll_caption = "This record is featured in “#{coll.title}.”" %>
+      <a href="/special_collections/<%= coll.path %>" class="btn-featured-record" title="<%= coll_caption %>" id="exhibit-banner">
+        <span class="glyphicon glyphicon-star"></span>
+        <strong><%= coll_caption %></strong>
+      </a>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/special_collections/_search_results.html.erb
+++ b/app/views/special_collections/_search_results.html.erb
@@ -10,7 +10,7 @@
     <div class="panel panel-primary collection-search-panel">
       <div class="panel-body search-body">
         <%= form_tag search_action_url, :method => :get, :class => 'search-query-form form-inline clearfix' do %>
-          <%= render_hash_as_hidden_fields(params_for_search(:f => { :special_collection => ["#{@special_collection.path}"] }).except(:q, :search_field, :qt, :page, :utf8)) %>
+          <%= render_hash_as_hidden_fields(params_for_search(:f => { :special_collections => ["#{@special_collection.path}"] }).except(:q, :search_field, :qt, :page, :utf8)) %>
           <div class="input-group input-group-sm" role="search">
             <label for="q" class="sr-only"><%= t('blacklight.search.form.q') %></label>
             <%= search_field_tag :q, params[:q], :placeholder => "Search the collection...", :class => "search_q q form-control", :id => "q", :autofocus => should_autofocus_on_search_box?, "aria-label" => "Search the collection" %>


### PR DESCRIPTION
Closes #1739 and closes #1732. Fixes one of the SpecialCollections searches that broke when we moved to allowing records to be associated with multiple SpecialCollections. Also rescues in catalog#show when a record that is associated with a SpecialCollection but doesn't have CMLess view.